### PR TITLE
Relax max circuits for simulation

### DIFF
--- a/qiskit_acqua/operator.py
+++ b/qiskit_acqua/operator.py
@@ -19,6 +19,7 @@ import copy
 import itertools
 from functools import reduce
 import logging
+import sys
 
 import numpy as np
 from scipy import sparse as scisparse
@@ -728,10 +729,13 @@ class Operator(object):
         """
 
         # If the statevector is already a vector, skip the evaluation from quantum simulator.
+
+        if backend.startswith('local'):
+            self.MAX_CIRCUITS_PER_JOB = sys.maxsize
+
         if isinstance(input_circuit, np.ndarray):
             avg = self._eval_directly(input_circuit)
             std_dev = 0.0
-
         elif "statevector" in backend:
             execute_config['shots'] = 1
             avg = self._eval_with_statevector(operator_mode, input_circuit, backend, execute_config)

--- a/qiskit_acqua/quantumalgorithm.py
+++ b/qiskit_acqua/quantumalgorithm.py
@@ -24,6 +24,7 @@ Doing so requires that the required algorithm interface is implemented.
 
 from abc import ABC, abstractmethod
 import logging
+import sys
 
 import numpy as np
 from qiskit import __version__ as qiskit_version

--- a/qiskit_acqua/quantumalgorithm.py
+++ b/qiskit_acqua/quantumalgorithm.py
@@ -25,6 +25,7 @@ Doing so requires that the required algorithm interface is implemented.
 from abc import ABC, abstractmethod
 import logging
 import sys
+import functools
 
 import numpy as np
 from qiskit import __version__ as qiskit_version
@@ -193,9 +194,8 @@ class QuantumAlgorithm(ABC):
         for job in jobs:
             results.append(job.result(**self._qjob_config))
 
-        if len(jobs) == 1:
-            results = results[0]
-        return results
+        result = functools.reduce(lambda x, y: x + y, results)
+        return result
 
     @staticmethod
     def register_and_get_operational_backends(qconfig):

--- a/qiskit_acqua/quantumalgorithm.py
+++ b/qiskit_acqua/quantumalgorithm.py
@@ -150,6 +150,7 @@ class QuantumAlgorithm(ABC):
 
         if backend.startswith('local'):
             self._qjob_config.pop('wait', None)
+            self.MAX_CIRCUITS_PER_JOB = sys.maxsize
 
         my_backend = get_backend(backend)
         self._execute_config = {'shots': shots,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Previous max number of circuits should only limit for remote backends, there is no limitation for local backends.

## Description
<!--- Describe your changes in detail -->
1. Change  `MAX_CIRCUITS_PER_JOB` to maximum int if local simulator is used.
2. Combine the Result object for easy use rather than store them in a list. Thus, no matter local and remote backend, the usage is the same.
3. Bug fix for combining operator.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Bug fix and enhance user usability

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tests under acqua and acqua-chem

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.