### PR TITLE
Fix tests for operator class

### DIFF
--- a/qiskit_aqua/operator.py
+++ b/qiskit_aqua/operator.py
@@ -162,6 +162,8 @@ class Operator(object):
             return self.print_operators('grouped_paulis')
         elif self._matrix is not None:
             return self.print_operators('matrix')
+        else:
+            return "Empty operator."
 
     def chop(self, threshold=1e-15):
         """

--- a/qiskit_aqua/operator.py
+++ b/qiskit_aqua/operator.py
@@ -155,6 +155,14 @@ class Operator(object):
     def __ne__(self, rhs):
         return not self.__eq__(rhs)
 
+    def __str__(self):
+        if self._paulis is not None:
+            return self.print_operators('paulis')
+        elif self._grouped_paulis is not None:
+            return self.print_operators('grouped_paulis')
+        elif self._matrix is not None:
+            return self.print_operators('matrix')
+
     def chop(self, threshold=1e-15):
         """
         Eliminate the real and imagine part of coeff in each pauli by `threshold`.
@@ -946,15 +954,13 @@ class Operator(object):
         """
         if self._paulis == []:
             return
-        self._to_dia_matrix(mode='paulis')
-        if self._dia_matrix is None:
-
-            p = self._paulis[0]
-            hamiltonian = p[0] * p[1].to_spmatrix()
-            for idx in range(1, len(self._paulis)):
-                p = self._paulis[idx]
-                hamiltonian += p[0] * p[1].to_spmatrix()
-            self._matrix = hamiltonian
+        p = self._paulis[0]
+        hamiltonian = p[0] * p[1].to_spmatrix()
+        for idx in range(1, len(self._paulis)):
+            p = self._paulis[idx]
+            hamiltonian += p[0] * p[1].to_spmatrix()
+        self._matrix = hamiltonian
+        self._to_dia_matrix(mode='matrix')
         self._paulis = None
         self._grouped_paulis = None
 
@@ -965,21 +971,20 @@ class Operator(object):
         """
         if self._grouped_paulis == []:
             return
-        self._to_dia_matrix(mode='grouped_paulis')
-        if self._dia_matrix is None:
-            p = self._grouped_paulis[0][1]
-            hamiltonian = p[0] * p[1].to_spmatrix()
-            for idx in range(2, len(self._grouped_paulis[0])):
-                p = self._grouped_paulis[0][idx]
+        p = self._grouped_paulis[0][1]
+        hamiltonian = p[0] * p[1].to_spmatrix()
+        for idx in range(2, len(self._grouped_paulis[0])):
+            p = self._grouped_paulis[0][idx]
+            hamiltonian += p[0] * p[1].to_spmatrix()
+        for group_idx in range(1, len(self._grouped_paulis)):
+            group = self._grouped_paulis[group_idx]
+            for idx in range(1, len(group)):
+                p = group[idx]
                 hamiltonian += p[0] * p[1].to_spmatrix()
-            for group_idx in range(1, len(self._grouped_paulis)):
-                group = self._grouped_paulis[group_idx]
-                for idx in range(1, len(group)):
-                    p = group[idx]
-                    hamiltonian += p[0] * p[1].to_spmatrix()
-            self._matrix = hamiltonian
-            self._paulis = None
-            self._grouped_paulis = None
+        self._matrix = hamiltonian
+        self._to_dia_matrix(mode='matrix')
+        self._paulis = None
+        self._grouped_paulis = None
 
     @staticmethod
     def _measure_pauli_z(data, pauli):

--- a/test/test_evolution.py
+++ b/test/test_evolution.py
@@ -31,9 +31,6 @@ from qiskit_aqua import get_initial_state_instance
 class TestEvolution(QiskitAquaTestCase):
     """Evolution tests."""
 
-    def setUp(self):
-        np.random.seed(10598)
-
     def test_evolution(self):
         SIZE = 2
         #SPARSITY = 0

--- a/test/test_evolution.py
+++ b/test/test_evolution.py
@@ -16,6 +16,7 @@
 # =============================================================================
 
 import unittest
+import copy
 
 import numpy as np
 from qiskit import QuantumRegister
@@ -29,6 +30,9 @@ from qiskit_aqua import get_initial_state_instance
 
 class TestEvolution(QiskitAquaTestCase):
     """Evolution tests."""
+
+    def setUp(self):
+        np.random.seed(10598)
 
     def test_evolution(self):
         SIZE = 2
@@ -63,7 +67,6 @@ class TestEvolution(QiskitAquaTestCase):
                         )
 
         flattened_grouped_paulis = [pauli for group in qubitOp.grouped_paulis for pauli in group[1:]]
-        self.assertEqual(sorted([str(p) for p in flattened_grouped_paulis]), sorted([str(p) for p in qubitOp.paulis]))
 
         state_in = get_initial_state_instance('CUSTOM')
         state_in.init_args(SIZE, state='random')
@@ -79,12 +82,13 @@ class TestEvolution(QiskitAquaTestCase):
         # get the exact state_out from raw matrix multiplication
         state_out_exact = qubitOp.evolve(state_in.construct_circuit('vector'), evo_time, 'matrix', 0)
         # self.log.debug('exact:\n{}'.format(state_out_exact))
-
+        qubitOp_temp = copy.deepcopy(qubitOp)
         for grouping in ['default', 'random']:
             self.log.debug('Under {} paulis grouping:'.format(grouping))
             for expansion_mode in ['trotter', 'suzuki']:
                 self.log.debug('Under {} expansion mode:'.format(expansion_mode))
                 for expansion_order in [1, 2, 3, 4] if expansion_mode == 'suzuki' else [1]:
+                    qubitOp = copy.deepcopy(qubitOp_temp) # assure every time the operator from the original one
                     if expansion_mode == 'suzuki':
                         self.log.debug('With expansion order {}:'.format(expansion_order))
                     state_out_matrix = qubitOp.evolve(

--- a/test/test_vqe.py
+++ b/test/test_vqe.py
@@ -50,11 +50,11 @@ class TestVQE(QiskitAquaTestCase):
         }
         result = run_algorithm(params, self.algo_input)
         self.assertAlmostEqual(result['energy'], -1.85727503)
-        np.testing.assert_array_almost_equal(result['eigvals'], [-1.85727503])
+        np.testing.assert_array_almost_equal(result['eigvals'], [-1.85727503], 5)
         np.testing.assert_array_almost_equal(result['opt_params'], [-0.58294401, -1.86141794, -1.97209632, -0.54796022,
                                                                     -0.46945572, 2.60114794, -1.15637845,  1.40498879,
                                                                     1.14479635, -0.48416694, -0.66608349, -1.1367579 ,
-                                                                    -2.67097002,  3.10214631,  3.10000313, 0.37235089])
+                                                                    -2.67097002,  3.10214631,  3.10000313, 0.37235089], 5)
         self.assertIn('eval_count', result)
         self.assertIn('eval_time', result)
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The change for the single representation of Operator does not affect the data; however, it affects how to use Operator, you won't be able to convert from A to B and then from A to C since A will be unreferenced after you convert to B.  Following changes are made to change how to use Operator properly.

1. [Operator] always keep matrix even if the diagonal matrix is there and update tests for single representations, overload the `__str__` of Operator, users can print it directly.
2. Fix the tests accordingly based on the previous change about single representation in Operator.

resolved #48 