### PR TITLE
Undefined name: 't' --> 'w[i, j]'

### DIFF
--- a/qiskit_aqua/ising/stableset.py
+++ b/qiskit_aqua/ising/stableset.py
@@ -60,7 +60,7 @@ def random_graph(n, edge_prob = 0.5, savefile=None):
             for i in range(n):
                 for j in range(i+1, n):
                     if w[i, j] != 0:
-                        outfile.write('{} {} {}\n'.format(i + 1, j + 1, t))
+                        outfile.write('{} {} {}\n'.format(i + 1, j + 1, w[i, j]))
     return w
 
 


### PR DESCRIPTION
Solution discussed at https://github.com/Qiskit/aqua/issues/79#issuecomment-412371882

Related to #65  @liupibm @chunfuchen 

[flake8](http://flake8.pycqa.org) testing of https://github.com/Qiskit/aqua on Python 3.7.0

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
/home/travis/virtualenv/python3.7.0/lib/python3.7/site-packages/pycodestyle.py:113: FutureWarning: Possible nested set at position 1
  EXTRANEOUS_WHITESPACE_REGEX = re.compile(r'[[({] | []}),;:]')
./qiskit_aqua/ising/stableset.py:63:73: F821 undefined name 't'
                        outfile.write('{} {} {}\n'.format(i + 1, j + 1, t))
                                                                        ^
1     F821 undefined name 't'
1
```

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments


