### PR TITLE
support negation of an operator

### DIFF
--- a/qiskit_aqua/operator.py
+++ b/qiskit_aqua/operator.py
@@ -136,6 +136,12 @@ class Operator(object):
         """Overload -= operation"""
         return self._extend_or_combine(rhs, 'inplace', op_isub)
 
+    def __neg__(self):
+        """Overload unary - """
+        ret = copy.deepcopy(self)
+        ret.scaling_coeff(-1.0)
+        return ret
+
     def __eq__(self, rhs):
         """Overload == operation"""
         if self._matrix is not None and rhs._matrix is not None:
@@ -156,6 +162,7 @@ class Operator(object):
                 if coeff != rhs_coeff:
                     return False
             return True
+
         if self._grouped_paulis is not None and rhs._grouped_paulis is not None:
             self._grouped_paulis_to_paulis()
             rhs._grouped_paulis_to_paulis()
@@ -181,7 +188,8 @@ class Operator(object):
             curr_repr = 'matrix'
             length = "{}x{}".format(2 ** self.num_qubits, 2 ** self.num_qubits)
 
-        ret = "Representation: {}, qubits: {}, size: {}{}".format(curr_repr, self.num_qubits, length, "" if group is None else " {}".format(group))
+        ret = "Representation: {}, qubits: {}, size: {}{}".format(
+            curr_repr, self.num_qubits, length, "" if group is None else " {}".format(group))
 
         return ret
 
@@ -600,11 +608,11 @@ class Operator(object):
                 circuit = QuantumCircuit(q)
                 for qubit_idx in range(n_qubits):
                     if pauli[1].v[qubit_idx] == 0 and pauli[1].w[qubit_idx] == 1:
-                        circuit.u3(np.pi, 0.0, np.pi, q[qubit_idx]) #x
+                        circuit.u3(np.pi, 0.0, np.pi, q[qubit_idx])  # x
                     elif pauli[1].v[qubit_idx] == 1 and pauli[1].w[qubit_idx] == 0:
-                        circuit.u1(np.pi, q[qubit_idx]) #z
+                        circuit.u1(np.pi, q[qubit_idx])  # z
                     elif pauli[1].v[qubit_idx] == 1 and pauli[1].w[qubit_idx] == 1:
-                        circuit.u3(np.pi, np.pi/2, np.pi/2, q[qubit_idx]) #y
+                        circuit.u3(np.pi, np.pi/2, np.pi/2, q[qubit_idx])  # y
 
                 all_circuits.append(circuit)
                 if len(circuit) != 0:
@@ -671,11 +679,11 @@ class Operator(object):
                 for qubit_idx in range(n_qubits):
                     # Measure X
                     if pauli[1].v[qubit_idx] == 0 and pauli[1].w[qubit_idx] == 1:
-                        circuit.u2(0.0, np.pi, q[qubit_idx]) #h
+                        circuit.u2(0.0, np.pi, q[qubit_idx])  # h
                     # Measure Y
                     elif pauli[1].v[qubit_idx] == 1 and pauli[1].w[qubit_idx] == 1:
-                        circuit.u1(np.pi/2, q[qubit_idx]).inverse() #s
-                        circuit.u2(0.0, np.pi, q[qubit_idx]) #h
+                        circuit.u1(np.pi/2, q[qubit_idx]).inverse()  # s
+                        circuit.u2(0.0, np.pi, q[qubit_idx])  # h
                     circuit.measure(q[qubit_idx], c[qubit_idx])
 
                 circuits.append(circuit)
@@ -712,11 +720,11 @@ class Operator(object):
                 for qubit_idx in range(n_qubits):
                     # Measure X
                     if tpb_set[0][1].v[qubit_idx] == 0 and tpb_set[0][1].w[qubit_idx] == 1:
-                        circuit.u2(0.0, np.pi, q[qubit_idx]) #h
+                        circuit.u2(0.0, np.pi, q[qubit_idx])  # h
                     # Measure Y
                     elif tpb_set[0][1].v[qubit_idx] == 1 and tpb_set[0][1].w[qubit_idx] == 1:
-                        circuit.u1(np.pi/2, q[qubit_idx]).inverse() #s
-                        circuit.u2(0.0, np.pi, q[qubit_idx]) #h
+                        circuit.u1(np.pi/2, q[qubit_idx]).inverse()  # s
+                        circuit.u2(0.0, np.pi, q[qubit_idx])  # h
                     circuit.measure(q[qubit_idx], c[qubit_idx])
                 circuits.append(circuit)
 
@@ -797,7 +805,8 @@ class Operator(object):
                 avg = self._eval_with_statevector(operator_mode, input_circuit, backend, execute_config)
                 std_dev = 0.0
             else:
-                avg, std_dev = self._eval_multiple_shots(operator_mode, input_circuit, backend, execute_config, qjob_config)
+                avg, std_dev = self._eval_multiple_shots(
+                    operator_mode, input_circuit, backend, execute_config, qjob_config)
         return avg, std_dev
 
     def convert(self, input_format, output_format, force=False):
@@ -972,6 +981,8 @@ class Operator(object):
             p = self._paulis[idx]
             hamiltonian += p[0] * p[1].to_spmatrix()
         self._matrix = hamiltonian
+        # print(self._matrix)
+        # print(self._matrix.shape)
         self._to_dia_matrix(mode='matrix')
         self._paulis = None
         self._grouped_paulis = None
@@ -1410,8 +1421,8 @@ class Operator(object):
             bool: is empty?
         """
         if self._matrix is None and self._dia_matrix is None \
-            and (self._paulis == [] or self._paulis is None) \
-            and (self._grouped_paulis == [] or self._grouped_paulis is None):
+                and (self._paulis == [] or self._paulis is None) \
+                and (self._grouped_paulis == [] or self._grouped_paulis is None):
 
             return True
         else:
@@ -1469,10 +1480,10 @@ class Operator(object):
         finite field
 
         Args:
-            matrix_in (np.ndarray): binary matrix
+            matrix_in (numpy.ndarray): binary matrix
 
         Returns:
-            np.ndarray : matrix_in in Echelon row form
+            numpy.ndarray : matrix_in in Echelon row form
         """
 
         size = matrix_in.shape
@@ -1508,10 +1519,10 @@ class Operator(object):
         Computes the kernel of a binary matrix on the binary finite field
 
         Args:
-            matrix_in (np.ndarray): binary matrix
+            matrix_in (numpy.ndarray): binary matrix
 
         Returns:
-            [np.ndarray]: the list of kernel vectors
+            [numpy.ndarray]: the list of kernel vectors
         """
 
         size = matrix_in.shape
@@ -1521,7 +1532,7 @@ class Operator(object):
 
         for col in range(size[1]):
             if (np.array_equal(matrix_in_id_ech[0:size[0], col], np.zeros(size[0])) and not
-            np.array_equal(matrix_in_id_ech[size[0]:, col], np.zeros(size[1]))) :
+                    np.array_equal(matrix_in_id_ech[size[0]:, col], np.zeros(size[1]))):
                 kernel.append(matrix_in_id_ech[size[0]:, col])
 
         return kernel
@@ -1554,7 +1565,7 @@ class Operator(object):
         for row in range(symm_shape[0]):
 
             Pauli_symmetries.append(Pauli(stacked_symmetries[row, : symm_shape[1] // 2],
-                                          stacked_symmetries[row, symm_shape[1] // 2 : ]))
+                                          stacked_symmetries[row, symm_shape[1] // 2:]))
 
             stacked_symm_del = np.delete(stacked_symmetries, (row), axis=0)
             for col in range(symm_shape[1] // 2):
@@ -1565,10 +1576,10 @@ class Operator(object):
                     if not (stacked_symm_del[symm_idx, col] == 0
                             and stacked_symm_del[symm_idx, col + symm_shape[1] // 2] in (0, 1)):
                         Z_or_I = False
-                if Z_or_I == True:
+                if Z_or_I:
                     if ((stacked_symmetries[row, col] == 1 and
                          stacked_symmetries[row, col + symm_shape[1] // 2] == 0) or
-                         (stacked_symmetries[row, col] == 1 and
+                        (stacked_symmetries[row, col] == 1 and
                          stacked_symmetries[row, col + symm_shape[1] // 2] == 1)):
                         sq_paulis.append(Pauli(np.zeros(symm_shape[1] // 2),
                                                np.zeros(symm_shape[1] // 2)))
@@ -1583,11 +1594,11 @@ class Operator(object):
                     if not (stacked_symm_del[symm_idx, col] in (0, 1) and
                             stacked_symm_del[symm_idx, col + symm_shape[1] // 2] == 0):
                         X_or_I = False
-                if X_or_I == True:
-                    if ( (stacked_symmetries[row, col] == 0 and
-                          stacked_symmetries[row, col + symm_shape[1] // 2] == 1) or
-                         (stacked_symmetries[row, col] == 1 and
-                          stacked_symmetries[row, col + symm_shape[1] // 2] == 1) ):
+                if X_or_I:
+                    if ((stacked_symmetries[row, col] == 0 and
+                         stacked_symmetries[row, col + symm_shape[1] // 2] == 1) or
+                        (stacked_symmetries[row, col] == 1 and
+                         stacked_symmetries[row, col + symm_shape[1] // 2] == 1)):
                         sq_paulis.append(Pauli(np.zeros(symm_shape[1] // 2), np.zeros(symm_shape[1] // 2)))
                         sq_paulis[row].v[col] = 1
                         sq_paulis[row].w[col] = 0
@@ -1597,16 +1608,16 @@ class Operator(object):
                 # case symmetries other than one at (row)  have Y or I on col qubit
                 Y_or_I = True
                 for symm_idx in range(symm_shape[0] - 1):
-                    if not ( (stacked_symm_del[symm_idx, col] == 1 and
-                              stacked_symm_del[symm_idx, col + symm_shape[1] // 2] == 1)
-                        or   (stacked_symm_del[symm_idx, col] == 0 and
-                              stacked_symm_del[symm_idx, col + symm_shape[1] // 2] == 0) ):
+                    if not ((stacked_symm_del[symm_idx, col] == 1 and
+                             stacked_symm_del[symm_idx, col + symm_shape[1] // 2] == 1)
+                            or (stacked_symm_del[symm_idx, col] == 0 and
+                                stacked_symm_del[symm_idx, col + symm_shape[1] // 2] == 0)):
                         Y_or_I = False
-                if Y_or_I == True:
-                    if ( (stacked_symmetries[row, col] == 0 and
-                          stacked_symmetries[row, col + symm_shape[1] // 2] == 1) or
-                         (stacked_symmetries[row, col] == 1 and
-                          stacked_symmetries[row, col + symm_shape[1] // 2] == 0) ):
+                if Y_or_I:
+                    if ((stacked_symmetries[row, col] == 0 and
+                         stacked_symmetries[row, col + symm_shape[1] // 2] == 1) or
+                        (stacked_symmetries[row, col] == 1 and
+                         stacked_symmetries[row, col + symm_shape[1] // 2] == 0)):
                         sq_paulis.append(Pauli(np.zeros(symm_shape[1] // 2), np.zeros(symm_shape[1] // 2)))
                         sq_paulis[row].v[col] = 1
                         sq_paulis[row].w[col] = 1
@@ -1684,7 +1695,6 @@ class Operator(object):
             self._paulis_to_grouped_paulis()
             self._paulis = None
 
-
     def scaling_coeff(self, scaling_factor):
         """
         Constant scale the coefficient in an operator.
@@ -1705,5 +1715,3 @@ class Operator(object):
             self._matrix *= scaling_factor
             if self._dia_matrix is not None:
                 self._dia_matrix *= scaling_factor
-
-

--- a/test/test_operator.py
+++ b/test/test_operator.py
@@ -397,6 +397,28 @@ class TestOperator(QiskitAquaTestCase):
         self.assertNotEqual(op1, op4)
         self.assertNotEqual(op3, op4)
 
+    def test_negation_operator(self):
+
+        paulis = ['IXYZ', 'XXZY', 'IIZZ', 'XXYY', 'ZZXX', 'YYYY']
+        coeffs = [0.2, 0.6, 0.8, -0.2, -0.6, -0.8]
+        op1 = Operator(paulis=[])
+        for coeff, pauli in zip(coeffs, paulis):
+            pauli_term = [coeff, label_to_pauli(pauli)]
+            op1 += Operator(paulis=[pauli_term])
+
+        paulis = ['IXYZ', 'XXZY', 'IIZZ', 'XXYY', 'ZZXX', 'YYYY']
+        coeffs = [-0.2, -0.6, -0.8, 0.2, 0.6, 0.8]
+        op2 = Operator(paulis=[])
+        for coeff, pauli in zip(coeffs, paulis):
+            pauli_term = [coeff, label_to_pauli(pauli)]
+            op2 += Operator(paulis=[pauli_term])
+
+        self.assertNotEqual(op1, op2)
+        self.assertEqual(op1, -op2)
+        self.assertEqual(-op1, op2)
+        op1.scaling_coeff(-1.0)
+        self.assertEqual(op1, op2)
+
     def test_chop_real_only(self):
 
         paulis = ['IXYZ', 'XXZY', 'IIZZ', 'XXYY', 'ZZXX', 'YYYY']


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
As title. for the current version, users can only use
```python
opC = opA - opB
```
but not
```python
opC = -opA + opB
```

this PR supports the second case.

### Details and comments


