### PR TITLE
enable job auto-recovery for remote backends

### DIFF
--- a/qiskit_aqua/__init__.py
+++ b/qiskit_aqua/__init__.py
@@ -20,7 +20,6 @@
 from .utils import cnx
 from .algorithmerror import AlgorithmError
 from .preferences import Preferences
-from .operator import Operator
 from .quantumalgorithm import QuantumAlgorithm
 from ._discover import (refresh_pluggables,
                         local_pluggables_types,

--- a/qiskit_aqua/__init__.py
+++ b/qiskit_aqua/__init__.py
@@ -19,6 +19,7 @@
 
 from .utils import cnx
 from .algorithmerror import AlgorithmError
+from .operator import Operator
 from .preferences import Preferences
 from .quantumalgorithm import QuantumAlgorithm
 from ._discover import (refresh_pluggables,
@@ -26,16 +27,19 @@ from ._discover import (refresh_pluggables,
                         local_pluggables,
                         get_pluggable_configuration)
 
+
 __version__ = '0.2.0'
 
 __all__ = ['AlgorithmError',
-           'Preferences',
            'Operator',
+           'Preferences',
            'QuantumAlgorithm',
            'refresh_pluggables',
            'local_pluggables_types',
            'local_pluggables',
-           'get_pluggable_configuration']
+           'get_pluggable_configuration',
+           'run_algorithm',
+           'run_algorithm_to_json']
 
 from ._discover import _PLUGGABLES
 
@@ -60,9 +64,4 @@ for pluggable_type in _PLUGGABLES.keys():
     exec(prefix + method)
     __all__.append(method)
 
-from .algomethods import run_algorithm
-__all__.append('run_algorithm')
-from .algomethods import run_algorithm_to_json
-__all__.append('run_algorithm_to_json')
-from .operator import Operator
-__all__.append('Operator')
+from .algomethods import run_algorithm, run_algorithm_to_json

--- a/qiskit_aqua/operator.py
+++ b/qiskit_aqua/operator.py
@@ -31,7 +31,7 @@ from qiskit import execute as q_execute
 from qiskit.tools.qi.pauli import Pauli, label_to_pauli, sgn_prod
 from qiskit.qasm import pi
 
-from qiskit_aqua import AlgorithmError
+from qiskit_aqua import AlgorithmError, QuantumAlgorithm
 from qiskit_aqua.utils import PauliGraph, summarize_circuits
 
 logger = logging.getLogger(__name__)

--- a/qiskit_aqua/operator.py
+++ b/qiskit_aqua/operator.py
@@ -30,8 +30,8 @@ from qiskit import QuantumRegister, ClassicalRegister, QuantumCircuit
 from qiskit.tools.qi.pauli import Pauli, label_to_pauli, sgn_prod
 from qiskit.qasm import pi
 
-from qiskit_aqua import AlgorithmError, QuantumAlgorithm
-from qiskit_aqua.utils import PauliGraph, summarize_circuits
+from qiskit_aqua import AlgorithmError
+from qiskit_aqua.utils import PauliGraph, summarize_circuits, run_circuits
 
 logger = logging.getLogger(__name__)
 
@@ -563,10 +563,9 @@ class Operator(object):
             if self._dia_matrix is None:
                 self._to_dia_matrix(mode='matrix')
 
-            result = QuantumAlgorithm.execute_with_maybe_autorecover(input_circuit, backend=backend,
-                                                                     execute_config=execute_config,
-                                                                     max_circuits_per_job=self.MAX_CIRCUITS_PER_JOB,
-                                                                     show_circuit_summary=self._summarize_circuits)
+            result = run_circuits(input_circuit, backend=backend, execute_config=execute_config,
+                                  max_circuits_per_job=self.MAX_CIRCUITS_PER_JOB,
+                                  show_circuit_summary=self._summarize_circuits)
             quantum_state = np.asarray(result.get_statevector(input_circuit))
 
             if self._dia_matrix is not None:
@@ -578,10 +577,9 @@ class Operator(object):
             self._check_representation("paulis")
             n_qubits = self.num_qubits
 
-            result = QuantumAlgorithm.execute_with_maybe_autorecover(input_circuit, backend=backend,
-                                                                     execute_config=execute_config,
-                                                                     max_circuits_per_job=self.MAX_CIRCUITS_PER_JOB,
-                                                                     show_circuit_summary=self._summarize_circuits)
+            result = run_circuits(input_circuit, backend=backend, execute_config=execute_config,
+                                  max_circuits_per_job=self.MAX_CIRCUITS_PER_JOB,
+                                  show_circuit_summary=self._summarize_circuits)
             simulator_initial_state = np.asarray(result.get_statevector(input_circuit))
 
             temp_config = copy.deepcopy(execute_config)
@@ -613,10 +611,9 @@ class Operator(object):
                 if len(circuit) != 0:
                     circuits_to_simulate.append(circuit)
 
-            result = QuantumAlgorithm.execute_with_maybe_autorecover(circuits_to_simulate, backend=backend,
-                                                                     execute_config=temp_config,
-                                                                     max_circuits_per_job=self.MAX_CIRCUITS_PER_JOB,
-                                                                     show_circuit_summary=self._summarize_circuits)
+            result = run_circuits(circuits_to_simulate, backend=backend, execute_config=temp_config,
+                                  max_circuits_per_job=self.MAX_CIRCUITS_PER_JOB,
+                                  show_circuit_summary=self._summarize_circuits)
 
             for idx, pauli in enumerate(self._paulis):
                 circuit = all_circuits[idx]
@@ -674,11 +671,9 @@ class Operator(object):
 
                 circuits.append(circuit)
 
-            result = QuantumAlgorithm.execute_with_maybe_autorecover(circuits, backend=backend,
-                                                                     execute_config=execute_config,
-                                                                     qjob_config=qjob_config,
-                                                                     max_circuits_per_job=self.MAX_CIRCUITS_PER_JOB,
-                                                                     show_circuit_summary=self._summarize_circuits)
+            result = run_circuits(circuits, backend=backend, execute_config=execute_config,
+                                  qjob_config=qjob_config, max_circuits_per_job=self.MAX_CIRCUITS_PER_JOB,
+                                  show_circuit_summary=self._summarize_circuits)
 
             avg_paulis = []
             for idx, pauli in enumerate(self._paulis):
@@ -707,11 +702,9 @@ class Operator(object):
                 circuits.append(circuit)
 
             # Execute all the stacked quantum circuits - one for each TPB set
-            result = QuantumAlgorithm.execute_with_maybe_autorecover(circuits, backend=backend,
-                                                                     execute_config=execute_config,
-                                                                     qjob_config=qjob_config,
-                                                                     max_circuits_per_job=self.MAX_CIRCUITS_PER_JOB,
-                                                                     show_circuit_summary=self._summarize_circuits)
+            result = run_circuits(circuits, backend=backend, execute_config=execute_config,
+                                  qjob_config=qjob_config, max_circuits_per_job=self.MAX_CIRCUITS_PER_JOB,
+                                  show_circuit_summary=self._summarize_circuits)
 
             for tpb_idx, tpb_set in enumerate(self._grouped_paulis):
                 avg_paulis = []

--- a/qiskit_aqua/operator.py
+++ b/qiskit_aqua/operator.py
@@ -683,19 +683,24 @@ class Operator(object):
 
                 circuits.append(circuit)
 
-            jobs = []
-            chunks = int(np.ceil(len(circuits) / self.MAX_CIRCUITS_PER_JOB))
-            for i in range(chunks):
-                sub_circuits = circuits[i*self.MAX_CIRCUITS_PER_JOB:(i+1)*self.MAX_CIRCUITS_PER_JOB]
-                jobs.append(q_execute(sub_circuits, backend=backend, **execute_config))
+            # jobs = []
+            # chunks = int(np.ceil(len(circuits) / self.MAX_CIRCUITS_PER_JOB))
+            # for i in range(chunks):
+            #     sub_circuits = circuits[i*self.MAX_CIRCUITS_PER_JOB:(i+1)*self.MAX_CIRCUITS_PER_JOB]
+            #     jobs.append(q_execute(sub_circuits, backend=backend, **execute_config))
 
-            if self._summarize_circuits and logger.isEnabledFor(logging.DEBUG):
-                logger.debug(summarize_circuits(circuits))
+            # if self._summarize_circuits and logger.isEnabledFor(logging.DEBUG):
+            #     logger.debug(summarize_circuits(circuits))
 
-            results = []
-            for job in jobs:
-                results.append(job.result(**qjob_config))
-            result = reduce(lambda x, y: x + y, results)
+            # results = []
+            # for job in jobs:
+            #     results.append(job.result(**qjob_config))
+            # result = reduce(lambda x, y: x + y, results)
+
+            result = QuantumAlgorithm.execute_with_autorecover(circuits, backend=backend,
+                                                               execute_config=execute_config,
+                                                               qjob_config=qjob_config,
+                                                               show_circuit_summary=self._summarize_circuits)
 
             avg_paulis = []
             for idx, pauli in enumerate(self._paulis):
@@ -724,19 +729,24 @@ class Operator(object):
                 circuits.append(circuit)
 
             # Execute all the stacked quantum circuits - one for each TPB set
-            jobs = []
-            chunks = int(np.ceil(len(circuits) / self.MAX_CIRCUITS_PER_JOB))
-            for i in range(chunks):
-                sub_circuits = circuits[i*self.MAX_CIRCUITS_PER_JOB:(i+1)*self.MAX_CIRCUITS_PER_JOB]
-                jobs.append(q_execute(sub_circuits, backend=backend, **execute_config))
+            # jobs = []
+            # chunks = int(np.ceil(len(circuits) / self.MAX_CIRCUITS_PER_JOB))
+            # for i in range(chunks):
+            #     sub_circuits = circuits[i*self.MAX_CIRCUITS_PER_JOB:(i+1)*self.MAX_CIRCUITS_PER_JOB]
+            #     jobs.append(q_execute(sub_circuits, backend=backend, **execute_config))
 
-            if self._summarize_circuits and logger.isEnabledFor(logging.DEBUG):
-                logger.debug(summarize_circuits(circuits))
+            # if self._summarize_circuits and logger.isEnabledFor(logging.DEBUG):
+            #     logger.debug(summarize_circuits(circuits))
 
-            results = []
-            for job in jobs:
-                results.append(job.result(**qjob_config))
-            result = reduce(lambda x, y: x + y, results)
+            # results = []
+            # for job in jobs:
+            #     results.append(job.result(**qjob_config))
+            # result = reduce(lambda x, y: x + y, results)
+
+            result = QuantumAlgorithm.execute_with_autorecover(circuits, backend=backend,
+                                                               execute_config=execute_config,
+                                                               qjob_config=qjob_config,
+                                                               show_circuit_summary=self._summarize_circuits)
 
             for tpb_idx, tpb_set in enumerate(self._grouped_paulis):
                 avg_paulis = []

--- a/qiskit_aqua/quantumalgorithm.py
+++ b/qiskit_aqua/quantumalgorithm.py
@@ -232,9 +232,9 @@ class QuantumAlgorithm(ABC):
         if not isinstance(circuits, list):
             circuits = [circuits]
 
+        my_backend = get_backend(backend)
         with_autorecover = False if my_backend.configuration()['simulator'] else True
 
-        my_backend = get_backend(backend)
         qobjs = []
         jobs = []
         chunks = int(np.ceil(len(circuits) / max_circuits_per_job))

--- a/qiskit_aqua/quantumalgorithm.py
+++ b/qiskit_aqua/quantumalgorithm.py
@@ -204,8 +204,6 @@ class QuantumAlgorithm(ABC):
         return result
 
     @staticmethod
-
-    @staticmethod
     def register_and_get_operational_backends(*args, provider_class=IBMQProvider, **kwargs):
         try:
             for provider in q_registered_providers():

--- a/qiskit_aqua/quantumalgorithm.py
+++ b/qiskit_aqua/quantumalgorithm.py
@@ -199,9 +199,9 @@ class QuantumAlgorithm(ABC):
         Returns:
             Result: Result object
         """
-        result = self.execute_with_autorecover(circuits, self._backend, self._execute_config,
-                                               self._qjob_config, max_circuits_per_job=self.MAX_CIRCUITS_PER_JOB,
-                                               show_circuit_summary=self._show_circuit_summary)
+        result = self.execute_with_maybe_autorecover(circuits, self._backend, self._execute_config,
+                                                     self._qjob_config, max_circuits_per_job=self.MAX_CIRCUITS_PER_JOB,
+                                                     show_circuit_summary=self._show_circuit_summary)
         if self._show_circuit_summary:
             self.disable_circuit_summary()
 
@@ -253,7 +253,6 @@ class QuantumAlgorithm(ABC):
             logger.debug(summarize_circuits(circuits))
 
         results = []
-
         if with_autorecover:
             for idx in range(len(jobs)):
                 job = jobs[idx]
@@ -271,7 +270,8 @@ class QuantumAlgorithm(ABC):
 
                     except Exception as e:
                         # if terra raise any error, which means something wrong, re-run it
-                        logger.warning("FAILURE: the {}-th chunk of circuits, job id: {}, Terra error: {} ".format(idx, job_id, e))
+                        logger.warning(
+                            "FAILURE: the {}-th chunk of circuits, job id: {}, Terra error: {} ".format(idx, job_id, e))
 
                     # keep querying the status until it is okay.
                     while True:
@@ -303,7 +303,8 @@ class QuantumAlgorithm(ABC):
 
         if len(results) != 0:
             result = functools.reduce(lambda x, y: x + y, results)
-
+        else:
+            result = None
         return result
 
     @staticmethod

--- a/qiskit_aqua/quantumalgorithm.py
+++ b/qiskit_aqua/quantumalgorithm.py
@@ -25,21 +25,17 @@ Doing so requires that the required algorithm interface is implemented.
 from abc import ABC, abstractmethod
 import logging
 import sys
-import functools
-import time
 
 import numpy as np
 from qiskit import __version__ as qiskit_version
 from qiskit import register as q_register
 from qiskit import unregister as q_unregister
 from qiskit import registered_providers as q_registered_providers
-from qiskit import execute as q_execute, compile as q_compile
 from qiskit import available_backends, get_backend
 from qiskit.backends.ibmq import IBMQProvider
-from qiskit.backends.jobstatus import JobStatus
 
 from qiskit_aqua import AlgorithmError
-from qiskit_aqua.utils import summarize_circuits
+from qiskit_aqua.utils import run_circuits
 from qiskit_aqua import Preferences
 
 logger = logging.getLogger(__name__)
@@ -199,113 +195,15 @@ class QuantumAlgorithm(ABC):
         Returns:
             Result: Result object
         """
-        result = self.execute_with_maybe_autorecover(circuits, self._backend, self._execute_config,
-                                                     self._qjob_config, max_circuits_per_job=self.MAX_CIRCUITS_PER_JOB,
-                                                     show_circuit_summary=self._show_circuit_summary)
+        result = run_circuits(circuits, self._backend, self._execute_config,
+                              self._qjob_config, max_circuits_per_job=self.MAX_CIRCUITS_PER_JOB,
+                              show_circuit_summary=self._show_circuit_summary)
         if self._show_circuit_summary:
             self.disable_circuit_summary()
 
         return result
 
     @staticmethod
-    def execute_with_maybe_autorecover(circuits, backend, execute_config, qjob_config={},
-                                       max_circuits_per_job=sys.maxsize, show_circuit_summary=False):
-        """
-        An execution wrapper with qiskit-terra, with auto recover capability.
-
-        By default, simulator backend will not use autorecover feature.
-
-        Args:
-            circuits (QuantumCircuit or list[QuantumCircuit]): circuits to execute
-            backend (str): name of backend
-            execute_config (dict): settings for qiskit execute (or compile)
-            qjob_config (dict): settings for job object, like timeout and wait
-            max_circuits_per_job (int): the maximum number of job, default is unlimited but 300 is limited if you
-                                        submit to a remote backend
-            show_circuit_summary (bool): showing the summary of submitted circuits.
-
-        Returns:
-            Result: Result object
-        """
-
-        # max_circuits_per_job = QuantumAlgorithm.MAX_CIRCUITS_PER_JOB
-        if not isinstance(circuits, list):
-            circuits = [circuits]
-
-        my_backend = get_backend(backend)
-        with_autorecover = False if my_backend.configuration()['simulator'] else True
-
-        qobjs = []
-        jobs = []
-        chunks = int(np.ceil(len(circuits) / max_circuits_per_job))
-
-        for i in range(chunks):
-            sub_circuits = circuits[i * max_circuits_per_job:(i + 1) * max_circuits_per_job]
-            qobj = q_compile(sub_circuits, my_backend, **execute_config)
-            job = my_backend.run(qobj)
-            jobs.append(job)
-            qobjs.append(qobj)
-
-        logger.info("There are {} circuits and they are chunked into {} chunks, each with {} circutis.".format(
-            len(circuits), chunks, max_circuits_per_job))
-
-        if logger.isEnabledFor(logging.DEBUG) and show_circuit_summary:
-            logger.debug(summarize_circuits(circuits))
-
-        results = []
-        if with_autorecover:
-            for idx in range(len(jobs)):
-                job = jobs[idx]
-                job_id = job.id()
-                logger.info("Running {}-th chunk circuits, job id: {}".format(idx, job_id))
-                while True:
-                    try:
-                        result = job.result(**qjob_config)
-                        if result.status == 'COMPLETED':
-                            results.append(result)
-                            logger.info("COMPLETED the {}-th chunk of circuits, job id: {}".format(idx, job_id))
-                            break
-                        else:
-                            logger.warning("FAILURE: the {}-th chunk of circuits, job id: {}".format(idx, job_id))
-
-                    except Exception as e:
-                        # if terra raise any error, which means something wrong, re-run it
-                        logger.warning(
-                            "FAILURE: the {}-th chunk of circuits, job id: {}, Terra error: {} ".format(idx, job_id, e))
-
-                    # keep querying the status until it is okay.
-                    while True:
-                        try:
-                            job_status = job.status()
-                            break
-                        except Exception as e:
-                            logger.warning(
-                                "FAILURE: job id: {}, status: 'FAIL_TO_GET_STATUS' ({})".format(job_id, e))
-                            time.sleep(5)
-
-                    logger.info("Job status: {}".format(job_status))
-                    # when reach here, it means the job fails. let's check what kinds of failure it is.
-                    if job_status == JobStatus.DONE:
-                        logger.info("Job ({}) is completed anyway, retrieve result from backend.".format(job_id))
-                        job = my_backend.retrieve_job(job_id)
-                    elif job_status == JobStatus.RUNNING or job_status == JobStatus.QUEUED:
-                        logger.info("Job ({}) is {}, but encounter an exception, recover it from backend.".format(
-                            job_id, job_status))
-                        job = my_backend.retrieve_job(job_id)
-                    else:
-                        logger.info("Fail to run Job ({}), resubmit it.".format(job_id))
-                        qobj = qobjs[idx]
-                        job = my_backend.run(qobj)
-        else:
-            results = []
-            for job in jobs:
-                results.append(job.result(**qjob_config))
-
-        if len(results) != 0:
-            result = functools.reduce(lambda x, y: x + y, results)
-        else:
-            result = None
-        return result
 
     @staticmethod
     def register_and_get_operational_backends(*args, provider_class=IBMQProvider, **kwargs):

--- a/qiskit_aqua/utils/__init__.py
+++ b/qiskit_aqua/utils/__init__.py
@@ -27,7 +27,7 @@ from .dataset_helper import (get_feature_dimension, get_num_classes,
                              split_dataset_to_data_and_labels, map_label_to_class_name,
                              reduce_dim_to_via_pca)
 from .qpsolver import optimize_svm
-
+from .run_circuits import run_circuits
 
 __all__ = ['tensorproduct',
            'PauliGraph',
@@ -46,4 +46,5 @@ __all__ = ['tensorproduct',
            'split_dataset_to_data_and_labels',
            'map_label_to_class_name',
            'reduce_dim_to_via_pca',
-           'optimize_svm']
+           'optimize_svm',
+           'run_circuits']

--- a/qiskit_aqua/utils/run_circuits.py
+++ b/qiskit_aqua/utils/run_circuits.py
@@ -72,14 +72,15 @@ def run_circuits(circuits, backend, execute_config, qjob_config={},
         jobs.append(job)
         qobjs.append(qobj)
 
-    logger.info("There are {} circuits and they are chunked into"
-                "{} chunks, each with {} circutis.".format(len(circuits), chunks, max_circuits_per_job))
-
     if logger.isEnabledFor(logging.DEBUG) and show_circuit_summary:
         logger.debug(summarize_circuits(circuits))
 
     results = []
     if with_autorecover:
+
+        logger.info("There are {} circuits and they are chunked into "
+                "{} chunks, each with {} circutis.".format(len(circuits), chunks, max_circuits_per_job))
+
         for idx in range(len(jobs)):
             job = jobs[idx]
             job_id = job.id()
@@ -95,11 +96,11 @@ def run_circuits(circuits, backend, execute_config, qjob_config={},
                         logger.warning("FAILURE: the {}-th chunk of circuits, job id: {}".format(idx, job_id))
                 except JobError as e:
                     # if terra raise any error, which means something wrong, re-run it
-                    logger.warning("FAILURE: the {}-th chunk of circuits, job id: {},"
+                    logger.warning("FAILURE: the {}-th chunk of circuits, job id: {}, "
                                    "Terra job error: {} ".format(idx, job_id, e))
                 except Exception as e:
                     # if terra raise any error, which means something wrong, re-run it
-                    raise AlgorithmError("FAILURE: the {}-th chunk of circuits, job id: {}"
+                    raise AlgorithmError("FAILURE: the {}-th chunk of circuits, job id: {}, "
                                          "Terra unknown error: {} ".format(idx, job_id, e)) from e
 
                 # keep querying the status until it is okay.
@@ -108,11 +109,11 @@ def run_circuits(circuits, backend, execute_config, qjob_config={},
                         job_status = job.status()
                         break
                     except JobError as e:
-                        logger.warning("FAILURE: job id: {},"
+                        logger.warning("FAILURE: job id: {}, "
                                        "status: 'FAIL_TO_GET_STATUS' Terra job error: {}".format(job_id, e))
                         time.sleep(5)
                     except Exception as e:
-                        raise AlgorithmError("FAILURE: job id: {},"
+                        raise AlgorithmError("FAILURE: job id: {}, "
                                              "status: 'FAIL_TO_GET_STATUS' ({})".format(job_id, e)) from e
 
                 logger.info("Job status: {}".format(job_status))
@@ -121,7 +122,7 @@ def run_circuits(circuits, backend, execute_config, qjob_config={},
                     logger.info("Job ({}) is completed anyway, retrieve result from backend.".format(job_id))
                     job = my_backend.retrieve_job(job_id)
                 elif job_status == JobStatus.RUNNING or job_status == JobStatus.QUEUED:
-                    logger.info("Job ({}) is {}, but encounter an exception,"
+                    logger.info("Job ({}) is {}, but encounter an exception, "
                                 "recover it from backend.".format(job_id, job_status))
                     job = my_backend.retrieve_job(job_id)
                 else:

--- a/qiskit_aqua/utils/run_circuits.py
+++ b/qiskit_aqua/utils/run_circuits.py
@@ -1,0 +1,140 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2018 IBM.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# =============================================================================
+
+import sys
+import logging
+import time
+import functools
+
+import numpy as np
+from qiskit import get_backend, compile as q_compile
+from qiskit.backends.jobstatus import JobStatus
+from qiskit.backends import JobError
+
+from qiskit_aqua.algorithmerror import AlgorithmError
+from qiskit_aqua.utils import summarize_circuits
+
+logger = logging.getLogger(__name__)
+
+
+def run_circuits(circuits, backend, execute_config, qjob_config={},
+                 max_circuits_per_job=sys.maxsize, show_circuit_summary=False):
+    """
+    An execution wrapper with Qiskit-Terra, with job auto recover capability.
+
+    The autorecovery feature is only applied for non-simulator backend.
+    This wraper will try to get the result no matter how long it costs.
+
+    Args:
+        circuits (QuantumCircuit or list[QuantumCircuit]): circuits to execute
+        backend (str): name of backend
+        execute_config (dict): settings for qiskit execute (or compile)
+        qjob_config (dict): settings for job object, like timeout and wait
+        max_circuits_per_job (int): the maximum number of job, default is unlimited but 300
+                is limited if you submit to a remote backend
+        show_circuit_summary (bool): showing the summary of submitted circuits.
+
+    Returns:
+        Result: Result object
+
+    Raises:
+        AlgorithmError: Any error except for JobError raised by Qiskit Terra
+    """
+
+    if not isinstance(circuits, list):
+        circuits = [circuits]
+
+    my_backend = get_backend(backend)
+    with_autorecover = False if my_backend.configuration()['simulator'] else True
+
+    qobjs = []
+    jobs = []
+    chunks = int(np.ceil(len(circuits) / max_circuits_per_job))
+
+    for i in range(chunks):
+        sub_circuits = circuits[i * max_circuits_per_job:(i + 1) * max_circuits_per_job]
+        qobj = q_compile(sub_circuits, my_backend, **execute_config)
+        job = my_backend.run(qobj)
+        jobs.append(job)
+        qobjs.append(qobj)
+
+    logger.info("There are {} circuits and they are chunked into"
+                "{} chunks, each with {} circutis.".format(len(circuits), chunks, max_circuits_per_job))
+
+    if logger.isEnabledFor(logging.DEBUG) and show_circuit_summary:
+        logger.debug(summarize_circuits(circuits))
+
+    results = []
+    if with_autorecover:
+        for idx in range(len(jobs)):
+            job = jobs[idx]
+            job_id = job.id()
+            logger.info("Running {}-th chunk circuits, job id: {}".format(idx, job_id))
+            while True:
+                try:
+                    result = job.result(**qjob_config)
+                    if result.status == 'COMPLETED':
+                        results.append(result)
+                        logger.info("COMPLETED the {}-th chunk of circuits, job id: {}".format(idx, job_id))
+                        break
+                    else:
+                        logger.warning("FAILURE: the {}-th chunk of circuits, job id: {}".format(idx, job_id))
+                except JobError as e:
+                    # if terra raise any error, which means something wrong, re-run it
+                    logger.warning("FAILURE: the {}-th chunk of circuits, job id: {},"
+                                   "Terra job error: {} ".format(idx, job_id, e))
+                except Exception as e:
+                    # if terra raise any error, which means something wrong, re-run it
+                    raise AlgorithmError("FAILURE: the {}-th chunk of circuits, job id: {}"
+                                         "Terra unknown error: {} ".format(idx, job_id, e)) from e
+
+                # keep querying the status until it is okay.
+                while True:
+                    try:
+                        job_status = job.status()
+                        break
+                    except JobError as e:
+                        logger.warning("FAILURE: job id: {},"
+                                       "status: 'FAIL_TO_GET_STATUS' Terra job error: {}".format(job_id, e))
+                        time.sleep(5)
+                    except Exception as e:
+                        raise AlgorithmError("FAILURE: job id: {},"
+                                             "status: 'FAIL_TO_GET_STATUS' ({})".format(job_id, e)) from e
+
+                logger.info("Job status: {}".format(job_status))
+                # when reach here, it means the job fails. let's check what kinds of failure it is.
+                if job_status == JobStatus.DONE:
+                    logger.info("Job ({}) is completed anyway, retrieve result from backend.".format(job_id))
+                    job = my_backend.retrieve_job(job_id)
+                elif job_status == JobStatus.RUNNING or job_status == JobStatus.QUEUED:
+                    logger.info("Job ({}) is {}, but encounter an exception,"
+                                "recover it from backend.".format(job_id, job_status))
+                    job = my_backend.retrieve_job(job_id)
+                else:
+                    logger.info("Fail to run Job ({}), resubmit it.".format(job_id))
+                    qobj = qobjs[idx]
+                    job = my_backend.run(qobj)
+    else:
+        results = []
+        for job in jobs:
+            results.append(job.result(**qjob_config))
+
+    if len(results) != 0:
+        result = functools.reduce(lambda x, y: x + y, results)
+    else:
+        result = None
+    return result

--- a/qiskit_aqua/utils/run_circuits.py
+++ b/qiskit_aqua/utils/run_circuits.py
@@ -99,7 +99,6 @@ def run_circuits(circuits, backend, execute_config, qjob_config={},
                     logger.warning("FAILURE: the {}-th chunk of circuits, job id: {}, "
                                    "Terra job error: {} ".format(idx, job_id, e))
                 except Exception as e:
-                    # if terra raise any error, which means something wrong, re-run it
                     raise AlgorithmError("FAILURE: the {}-th chunk of circuits, job id: {}, "
                                          "Terra unknown error: {} ".format(idx, job_id, e)) from e
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
resolve issue #117 

1. if the backend is not a `simulator`, aqua will try to catch the error throw by terra and handle it properly. 
Most errors come from connection problems, aqua will try to recover the job from the remote if it fails.
2. Unified the interface to terra, all executions use the static method in QuantumAlgorithm.

