### PR TITLE
support general pauli-type feature map

### DIFF
--- a/qiskit_aqua/algorithms/components/feature_maps/data_mapping.py
+++ b/qiskit_aqua/algorithms/components/feature_maps/data_mapping.py
@@ -15,9 +15,25 @@
 # limitations under the License.
 # =============================================================================
 
-from .feature_map import FeatureMap
-from .data_mapping import self_product
+"""
+This module contains the definition of data mapping function for feature map.
+"""
+
+import functools
+
+import numpy as np
 
 
-__all__ = ['FeatureMap',
-           'self_product']
+def self_product(x):
+    """
+    Define a function map from R^n to R.
+
+    Args:
+        x (np.ndarray): data
+
+    Returns:
+        double: the mapped value
+    """
+    coeff = x[0] if len(x) == 1 else \
+        functools.reduce(lambda m, n: (np.pi - m) * (np.pi - n), x)
+    return coeff

--- a/qiskit_aqua/algorithms/components/feature_maps/data_mapping.py
+++ b/qiskit_aqua/algorithms/components/feature_maps/data_mapping.py
@@ -35,5 +35,5 @@ def self_product(x):
         double: the mapped value
     """
     coeff = x[0] if len(x) == 1 else \
-        functools.reduce(lambda m, n: (np.pi - m) * (np.pi - n), x)
+        functools.reduce(lambda m, n: m * n, np.pi - x)
     return coeff

--- a/qiskit_aqua/algorithms/components/feature_maps/first_order_expansion.py
+++ b/qiskit_aqua/algorithms/components/feature_maps/first_order_expansion.py
@@ -24,6 +24,7 @@ import numpy as np
 from qiskit import CompositeGate, QuantumCircuit, QuantumRegister
 from qiskit.extensions.standard.u1 import U1Gate
 from qiskit.extensions.standard.u2 import U2Gate
+from qiskit.qasm import pi
 
 from qiskit_aqua.algorithms.components.feature_maps import FeatureMap
 
@@ -53,10 +54,17 @@ class FirstOrderExpansion(FeatureMap):
     }
 
     def __init__(self, configuration=None):
+        """Constructor."""
         super().__init__(configuration or self.FIRST_ORDER_EXPANSION_CONFIGURATION.copy())
         self._ret = {}
 
     def init_args(self, num_qubits, depth):
+        """Initializer.
+
+        Args:
+            num_qubits (int): number of qubits
+            depth (int): the number of repeated circuits
+        """
         self._num_qubits = num_qubits
         self._depth = depth
 
@@ -66,7 +74,7 @@ class FirstOrderExpansion(FeatureMap):
 
         for _ in range(self._depth):
             for i in range(x.shape[0]):
-                composite_gate._attach(U2Gate(0, np.pi, qr[i]))
+                composite_gate._attach(U2Gate(0, pi, qr[i]))
                 composite_gate._attach(U1Gate(2 * x[i], qr[i]))
 
         return composite_gate

--- a/qiskit_aqua/algorithms/components/feature_maps/first_order_expansion.py
+++ b/qiskit_aqua/algorithms/components/feature_maps/first_order_expansion.py
@@ -19,17 +19,11 @@ This module contains the definition of a base class for
 feature map. Several types of commonly used approaches.
 """
 
-
-import numpy as np
-from qiskit import CompositeGate, QuantumCircuit, QuantumRegister
-from qiskit.extensions.standard.u1 import U1Gate
-from qiskit.extensions.standard.u2 import U2Gate
-from qiskit.qasm import pi
-
-from qiskit_aqua.algorithms.components.feature_maps import FeatureMap
+from qiskit_aqua.algorithms.components.feature_maps.pauli_expansion import PauliExpansion
+from qiskit_aqua.algorithms.components.feature_maps import self_product
 
 
-class FirstOrderExpansion(FeatureMap):
+class FirstOrderExpansion(PauliExpansion):
     """
     Mapping data with the first order expansion without entangling gates.
     Refer to https://arxiv.org/pdf/1804.11326.pdf for details.
@@ -58,51 +52,12 @@ class FirstOrderExpansion(FeatureMap):
         super().__init__(configuration or self.FIRST_ORDER_EXPANSION_CONFIGURATION.copy())
         self._ret = {}
 
-    def init_args(self, num_qubits, depth):
+    def init_args(self, num_qubits, depth, data_map_func=self_product):
         """Initializer.
 
         Args:
             num_qubits (int): number of qubits
             depth (int): the number of repeated circuits
+            data_map_func (Callable): a mapping function for data x
         """
-        self._num_qubits = num_qubits
-        self._depth = depth
-
-    def _build_composite_gate(self, x, qr):
-        composite_gate = CompositeGate("first_order_expansion",
-                                       [], [qr[i] for i in range(self._num_qubits)])
-
-        for _ in range(self._depth):
-            for i in range(x.shape[0]):
-                composite_gate._attach(U2Gate(0, pi, qr[i]))
-                composite_gate._attach(U1Gate(2 * x[i], qr[i]))
-
-        return composite_gate
-
-    def construct_circuit(self, x, qr=None, inverse=False):
-        """
-        Construct the first order expansion based on given data.
-
-        Args:
-            x (numpy.ndarray): 1-D to-be-transformed data.
-            qr (QauntumRegister): the QuantumRegister object for the circuit, if None,
-                                  generate new registers with name q.
-            inverse (bool): whether or not inverse the circuit
-
-        Returns:
-            QuantumCircuit: a quantum circuit transform data x.
-        """
-        if not isinstance(x, np.ndarray):
-            raise TypeError("x should be numpy array.")
-        if x.ndim != 1:
-            raise ValueError("x should be 1-D array.")
-        if x.shape[0] != self._num_qubits:
-            raise ValueError("number of qubits and data dimension must be the same.")
-
-        if qr is None:
-            qr = QuantumRegister(self._num_qubits, 'q')
-        qc = QuantumCircuit(qr)
-        composite_gate = self._build_composite_gate(x, qr)
-        qc._attach(composite_gate if not inverse else composite_gate.inverse())
-
-        return qc
+        super().init_args(num_qubits, depth, paulis=['Z'], data_map_func=data_map_func)

--- a/qiskit_aqua/algorithms/components/feature_maps/first_order_expansion.py
+++ b/qiskit_aqua/algorithms/components/feature_maps/first_order_expansion.py
@@ -19,11 +19,11 @@ This module contains the definition of a base class for
 feature map. Several types of commonly used approaches.
 """
 
-from qiskit_aqua.algorithms.components.feature_maps.pauli_expansion import PauliExpansion
+from qiskit_aqua.algorithms.components.feature_maps.pauli_z_expansion import PauliZExpansion
 from qiskit_aqua.algorithms.components.feature_maps import self_product
 
 
-class FirstOrderExpansion(PauliExpansion):
+class FirstOrderExpansion(PauliZExpansion):
     """
     Mapping data with the first order expansion without entangling gates.
     Refer to https://arxiv.org/pdf/1804.11326.pdf for details.
@@ -60,4 +60,4 @@ class FirstOrderExpansion(PauliExpansion):
             depth (int): the number of repeated circuits
             data_map_func (Callable): a mapping function for data x
         """
-        super().init_args(num_qubits, depth, paulis=['Z'], data_map_func=data_map_func)
+        super().init_args(num_qubits, depth, z_order=1, data_map_func=data_map_func)

--- a/qiskit_aqua/algorithms/components/feature_maps/pauli_expansion.py
+++ b/qiskit_aqua/algorithms/components/feature_maps/pauli_expansion.py
@@ -154,9 +154,9 @@ class PauliExpansion(FeatureMap):
 
         def get_coeff(paulis):
             # coeff for the rotation angle
-            where_z = np.where(np.asarray(list(paulis)) != 'I')[0]
-            coeff = x[where_z][0] if len(where_z) == 1 else \
-                functools.reduce(lambda m, n: (np.pi - m) * (np.pi - n), x[where_z])
+            where_non_i = np.where(np.asarray(list(paulis)) != 'I')[0]
+            coeff = x[where_non_i][0] if len(where_non_i) == 1 else \
+                functools.reduce(lambda m, n: (np.pi - m) * (np.pi - n), x[where_non_i])
             return coeff
 
         if qr is None:

--- a/qiskit_aqua/algorithms/components/feature_maps/pauli_expansion.py
+++ b/qiskit_aqua/algorithms/components/feature_maps/pauli_expansion.py
@@ -40,7 +40,7 @@ class PauliExpansion(FeatureMap):
     """
 
     PAULI_EXPANSION_CONFIGURATION = {
-        'name': 'PauliZExpansion',
+        'name': 'PauliExpansion',
         'description': 'Pauli expansion for feature map (any order)',
         'input_schema': {
             '$schema': 'http://json-schema.org/schema#',
@@ -65,7 +65,7 @@ class PauliExpansion(FeatureMap):
                 },
                 'paulis': {
                     'type': 'string',
-                    'default': 'Z'
+                    'default': 'Z,ZZ'
                 }
             },
             'additionalProperties': False
@@ -160,9 +160,9 @@ class PauliExpansion(FeatureMap):
             return coeff
 
         if qr is None:
-            qr = QuantumRegister(self._num_qubits)
-
+            qr = QuantumRegister(self._num_qubits, name='q')
         qc = QuantumCircuit(qr)
+
         for i in range(self._num_qubits):
             qc.u2(0, np.pi, qr[i])
         for pauli in self._pauli_strings:

--- a/qiskit_aqua/algorithms/components/feature_maps/pauli_expansion.py
+++ b/qiskit_aqua/algorithms/components/feature_maps/pauli_expansion.py
@@ -1,0 +1,176 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2018 IBM.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# =============================================================================
+"""
+This module contains the definition of a base class for
+feature map. Several types of commonly used approaches.
+"""
+
+import itertools
+import functools
+import logging
+
+import numpy as np
+from qiskit import QuantumCircuit, QuantumRegister
+from qiskit.tools.qi.pauli import label_to_pauli
+
+from qiskit_aqua import Operator
+from qiskit_aqua.algorithms.components.feature_maps import FeatureMap
+
+logger = logging.getLogger(__name__)
+
+
+class PauliExpansion(FeatureMap):
+    """
+    Mapping data with the second order expansion followed by entangling gates.
+    Refer to https://arxiv.org/pdf/1804.11326.pdf for details.
+    """
+
+    PAULI_EXPANSION_CONFIGURATION = {
+        'name': 'PauliZExpansion',
+        'description': 'Pauli expansion for feature map (any order)',
+        'input_schema': {
+            '$schema': 'http://json-schema.org/schema#',
+            'id': 'Pauli_Expansion_schema',
+            'type': 'object',
+            'properties': {
+                'depth': {
+                    'type': 'integer',
+                    'default': 2,
+                    'minimum': 1
+                },
+                'entangler_map': {
+                    'type': ['object', 'null'],
+                    'default': None
+                },
+                'entanglement': {
+                    'type': 'string',
+                    'default': 'full',
+                    'oneOf': [
+                        {'enum': ['full', 'linear']}
+                    ]
+                },
+                'paulis': {
+                    'type': 'string',
+                    'default': 'Z'
+                }
+            },
+            'additionalProperties': False
+        }
+    }
+
+    def __init__(self, configuration=None):
+        super().__init__(configuration or self.PAULI_EXPANSION_CONFIGURATION.copy())
+        self._ret = {}
+
+    def init_args(self, num_qubits, depth, entangler_map=None, entanglement='full', paulis='Z'):
+        """Initializer.
+
+        Args:
+            num_qubits (int): number of qubits
+            depth (int): the number of repeated circuits
+            entangler_map (dict):
+            entanglement (str): ['full', 'linear']
+            paulis (str): a comma-seperated string for to-be-used paulis
+        """
+        self._num_qubits = num_qubits
+        self._depth = depth
+        if entangler_map is None:
+            self._entangler_map = self.get_entangler_map(entanglement, num_qubits)
+        else:
+            self._entangler_map = self.validate_entangler_map(entangler_map, num_qubits)
+
+        self._pauli_strings = self._build_subset_paulis_string(paulis)
+
+    def _build_subset_paulis_string(self, paulis):
+
+        all_paulis = paulis.strip().split(",")
+        # fill out the paulis to the number of qubits
+        temp_paulis = []
+        for pauli in all_paulis:
+            len_pauli = len(pauli)
+            for j in itertools.combinations(range(self._num_qubits), len_pauli):
+                string_temp = ['I'] * self._num_qubits
+                for idx in range(len(j)):
+                    string_temp[j[idx]] = pauli[idx]
+                temp_paulis.append(''.join(string_temp))
+
+        # clean up string that can not be entangled.
+        final_paulis = []
+        for pauli in temp_paulis:
+            where_z = np.where(np.asarray(list(pauli)) != 'I')[0]
+            if len(where_z) == 1:
+                final_paulis.append(pauli)
+            else:
+                is_valid = True
+                for src, targ in itertools.combinations(where_z, 2):
+                    if src not in self._entangler_map:
+                        is_valid = False
+                        break
+                    else:
+                        if targ not in self._entangler_map[src]:
+                            is_valid = False
+                            break
+                if is_valid:
+                    final_paulis.append(pauli)
+                else:
+                    logger.warning("Due to the limited entangler_map, {} is skipped.".format(pauli))
+        logger.info("Pauli terms include: {}".format(final_paulis))
+        return final_paulis
+
+    def construct_circuit(self, x, qr=None, inverse=False):
+        """
+        Construct the second order expansion based on given data.
+
+        Args:
+            x (numpy.ndarray): 1-D to-be-transformed data.
+            qr (QauntumRegister): the QuantumRegister object for the circuit, if None,
+                                  generate new registers with name q.
+            inverse (bool): whether or not inverse the circuit
+
+        Returns:
+            QuantumCircuit: a quantum circuit transform data x.
+        """
+
+        if not isinstance(x, np.ndarray):
+            raise TypeError("x must be numpy array.")
+        if x.ndim != 1:
+            raise ValueError("x must be 1-D array.")
+        if x.shape[0] != self._num_qubits:
+            raise ValueError("number of qubits and data dimension must be the same.")
+
+        def get_coeff(paulis):
+            # coeff for the rotation angle
+            where_z = np.where(np.asarray(list(paulis)) != 'I')[0]
+            coeff = x[where_z][0] if len(where_z) == 1 else \
+                functools.reduce(lambda m, n: (np.pi - m) * (np.pi - n), x[where_z])
+            return coeff
+
+        if qr is None:
+            qr = QuantumRegister(self._num_qubits)
+
+        qc = QuantumCircuit(qr)
+        for i in range(self._num_qubits):
+            qc.u2(0, np.pi, qr[i])
+        for pauli in self._pauli_strings:
+            coeff = get_coeff(pauli)
+            p = label_to_pauli(pauli)
+            qc += Operator.construct_evolution_circuit([[coeff, p]], 1, 1, qr)
+
+        qc.data *= self._depth
+        if inverse:
+            qc.data = [gate.inverse() for gate in reversed(qc.data)]
+        return qc

--- a/qiskit_aqua/algorithms/components/feature_maps/pauli_z_expansion.py
+++ b/qiskit_aqua/algorithms/components/feature_maps/pauli_z_expansion.py
@@ -1,0 +1,179 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2018 IBM.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# =============================================================================
+"""
+This module contains the definition of a base class for
+feature map. Several types of commonly used approaches.
+"""
+
+import itertools
+import functools
+import logging
+
+import numpy as np
+from qiskit import QuantumCircuit, QuantumRegister
+from qiskit.tools.qi.pauli import label_to_pauli
+
+from qiskit_aqua import Operator
+from qiskit_aqua.algorithms.components.feature_maps import FeatureMap
+
+logger = logging.getLogger(__name__)
+
+
+class PauliZExpansion(FeatureMap):
+    """
+    Mapping data with the second order expansion followed by entangling gates.
+    Refer to https://arxiv.org/pdf/1804.11326.pdf for details.
+    """
+
+    PAULI_Z_EXPANSION_CONFIGURATION = {
+        'name': 'PauliZExpansion',
+        'description': 'Pauli Z expansion for feature map (any order)',
+        'input_schema': {
+            '$schema': 'http://json-schema.org/schema#',
+            'id': 'Pauli_Z_Expansion_schema',
+            'type': 'object',
+            'properties': {
+                'depth': {
+                    'type': 'integer',
+                    'default': 2,
+                    'minimum': 1
+                },
+                'entangler_map': {
+                    'type': ['object', 'null'],
+                    'default': None
+                },
+                'entanglement': {
+                    'type': 'string',
+                    'default': 'full',
+                    'oneOf': [
+                        {'enum': ['full', 'linear']}
+                    ]
+                },
+                'z_order': {
+                    'type': 'integer',
+                    'minimum': 1,
+                    'default': 2
+                }
+            },
+            'additionalProperties': False
+        }
+    }
+
+    def __init__(self, configuration=None):
+        super().__init__(configuration or self.PAULI_Z_EXPANSION_CONFIGURATION.copy())
+        self._ret = {}
+
+    def init_args(self, num_qubits, depth, entangler_map=None, entanglement='full', z_order=1):
+        """Initializer.
+
+        Args:
+            num_qubits (int): number of qubits
+            depth (int): the number of repeated circuits
+            entangler_map (dict):
+            entanglement (str): ['full', 'linear']
+            z_order (int): the order of Z expansion
+        """
+        self._num_qubits = num_qubits
+        self._depth = depth
+        if entangler_map is None:
+            self._entangler_map = self.get_entangler_map(entanglement, num_qubits)
+        else:
+            self._entangler_map = self.validate_entangler_map(entangler_map, num_qubits)
+
+        if z_order > num_qubits:
+            logger.warning("Z order ({}) is higher than number of qubits ({}), Z order will "
+                           "be changed to the number of qubits then.".format(z_order, num_qubits))
+            z_order = num_qubits
+        self._pauli_strings = self._build_subset_paulis_string(z_order)
+
+    def _build_subset_paulis_string(self, z_order):
+        temp_paulis = []
+        for i in range(1, z_order + 1):
+            # i mean how many Z will be added in the loop
+            for j in itertools.combinations(range(self._num_qubits), i):
+                pauli = ['I'] * self._num_qubits
+                for m in j:
+                    pauli[m] = 'Z'
+                pauli = ''.join(pauli)
+                temp_paulis.append(pauli)
+
+        # clean up string that can not be entangled.
+        final_paulis = []
+        for pauli in temp_paulis:
+            where_z = np.where(np.asarray(list(pauli)) != 'I')[0]
+            if len(where_z) == 1:
+                final_paulis.append(pauli)
+            else:
+                is_valid = True
+                for src, targ in itertools.combinations(where_z, 2):
+                    if src not in self._entangler_map:
+                        is_valid = False
+                        break
+                    else:
+                        if targ not in self._entangler_map[src]:
+                            is_valid = False
+                            break
+                if is_valid:
+                    final_paulis.append(pauli)
+                else:
+                    logger.warning("Due to the limited entangler_map, {} is skipped.".format(pauli))
+        logger.info("Pauli terms include: {}".format(final_paulis))
+        return final_paulis
+
+    def construct_circuit(self, x, qr=None, inverse=False):
+        """
+        Construct the second order expansion based on given data.
+
+        Args:
+            x (numpy.ndarray): 1-D to-be-transformed data.
+            qr (QauntumRegister): the QuantumRegister object for the circuit, if None,
+                                  generate new registers with name q.
+            inverse (bool): whether or not inverse the circuit
+
+        Returns:
+            QuantumCircuit: a quantum circuit transform data x.
+        """
+
+        if not isinstance(x, np.ndarray):
+            raise TypeError("x must be numpy array.")
+        if x.ndim != 1:
+            raise ValueError("x must be 1-D array.")
+        if x.shape[0] != self._num_qubits:
+            raise ValueError("number of qubits and data dimension must be the same.")
+
+        def get_coeff(paulis):
+            # coeff for the rotation angle
+            where_z = np.where(np.asarray(list(paulis)) != 'I')[0]
+            coeff = x[where_z][0] if len(where_z) == 1 else \
+                functools.reduce(lambda m, n: (np.pi - m) * (np.pi - n), x[where_z])
+            return coeff
+
+        if qr is None:
+            qr = QuantumRegister(self._num_qubits)
+
+        qc = QuantumCircuit(qr)
+        for i in range(self._num_qubits):
+            qc.u2(0, np.pi, qr[i])
+        for pauli in self._pauli_strings:
+            coeff = get_coeff(pauli)
+            p = label_to_pauli(pauli)
+            qc += Operator.construct_evolution_circuit([[coeff, p]], 1, 1, qr)
+
+        qc.data *= self._depth
+        if inverse:
+            qc.data = [gate.inverse() for gate in reversed(qc.data)]
+        return qc

--- a/qiskit_aqua/algorithms/components/feature_maps/pauli_z_expansion.py
+++ b/qiskit_aqua/algorithms/components/feature_maps/pauli_z_expansion.py
@@ -163,9 +163,9 @@ class PauliZExpansion(FeatureMap):
             return coeff
 
         if qr is None:
-            qr = QuantumRegister(self._num_qubits)
-
+            qr = QuantumRegister(self._num_qubits, name='q')
         qc = QuantumCircuit(qr)
+
         for i in range(self._num_qubits):
             qc.u2(0, np.pi, qr[i])
         for pauli in self._pauli_strings:

--- a/qiskit_aqua/algorithms/components/feature_maps/pauli_z_expansion.py
+++ b/qiskit_aqua/algorithms/components/feature_maps/pauli_z_expansion.py
@@ -157,9 +157,9 @@ class PauliZExpansion(FeatureMap):
 
         def get_coeff(paulis):
             # coeff for the rotation angle
-            where_z = np.where(np.asarray(list(paulis)) != 'I')[0]
-            coeff = x[where_z][0] if len(where_z) == 1 else \
-                functools.reduce(lambda m, n: (np.pi - m) * (np.pi - n), x[where_z])
+            where_non_i = np.where(np.asarray(list(paulis)) != 'I')[0]
+            coeff = x[where_non_i][0] if len(where_non_i) == 1 else \
+                functools.reduce(lambda m, n: (np.pi - m) * (np.pi - n), x[where_non_i])
             return coeff
 
         if qr is None:

--- a/qiskit_aqua/algorithms/components/feature_maps/pauli_z_expansion.py
+++ b/qiskit_aqua/algorithms/components/feature_maps/pauli_z_expansion.py
@@ -19,25 +19,11 @@ This module contains the definition of a base class for
 feature map. Several types of commonly used approaches.
 """
 
-from collections import OrderedDict
-import copy
-import itertools
-import logging
-
-import numpy as np
-from qiskit import QuantumCircuit, QuantumRegister
-from qiskit.tools.qi.pauli import label_to_pauli
-from qiskit.qasm import pi
-from sympy.core.numbers import NaN
-
-from qiskit_aqua import Operator
-from qiskit_aqua.algorithms.components.feature_maps import FeatureMap
+from qiskit_aqua.algorithms.components.feature_maps.pauli_expansion import PauliExpansion
 from qiskit_aqua.algorithms.components.feature_maps import self_product
 
-logger = logging.getLogger(__name__)
 
-
-class PauliZExpansion(FeatureMap):
+class PauliZExpansion(PauliExpansion):
     """
     Mapping data with the second order expansion followed by entangling gates.
     Refer to https://arxiv.org/pdf/1804.11326.pdf for details.
@@ -96,123 +82,8 @@ class PauliZExpansion(FeatureMap):
             z_order (str): z order
             data_map_func (Callable): a mapping function for data x
         """
-        self._num_qubits = num_qubits
-        self._depth = depth
-        if entangler_map is None:
-            self._entangler_map = self.get_entangler_map(entanglement, num_qubits)
-        else:
-            self._entangler_map = self.validate_entangler_map(entangler_map, num_qubits)
-
-        if z_order > num_qubits:
-            logger.warning("Z order ({}) is higher than number of qubits ({}), Z order will "
-                           "be changed to the number of qubits then.".format(z_order, num_qubits))
-            z_order = num_qubits
-        self._pauli_strings = self._build_subset_paulis_string(z_order)
-        self._data_map_func = data_map_func
-
-        self._magic_num = np.nan
-        self._param_pos = OrderedDict()
-        self._circuit_template = self._build_circuit_template()
-
-    def _build_circuit_template(self):
-        x = np.asarray([self._magic_num] * self._num_qubits)
-        qr = QuantumRegister(self._num_qubits, name='q')
-        qc = self.construct_circuit(x, qr)
-
-        for index in range(len(qc.data)):
-            gate_param = qc.data[index].param
-            param_sub_pos = []
-            for x in range(len(gate_param)):
-                if isinstance(gate_param[x], NaN):
-                    param_sub_pos.append(x)
-            if param_sub_pos != []:
-                self._param_pos[index] = param_sub_pos
-        return qc
-
-    def _build_subset_paulis_string(self, z_order):
-        temp_paulis = []
+        pauli_string = []
         for i in range(1, z_order + 1):
-            # i mean how many Z will be added in the loop
-            for j in itertools.combinations(range(self._num_qubits), i):
-                pauli = ['I'] * self._num_qubits
-                for m in j:
-                    pauli[m] = 'Z'
-                pauli = ''.join(pauli)
-                temp_paulis.append(pauli)
-
-        # clean up string that can not be entangled.
-        final_paulis = []
-        for pauli in temp_paulis:
-            where_z = np.where(np.asarray(list(pauli)) != 'I')[0]
-            if len(where_z) == 1:
-                final_paulis.append(pauli)
-            else:
-                is_valid = True
-                for src, targ in itertools.combinations(where_z, 2):
-                    if src not in self._entangler_map:
-                        is_valid = False
-                        break
-                    else:
-                        if targ not in self._entangler_map[src]:
-                            is_valid = False
-                            break
-                if is_valid:
-                    final_paulis.append(pauli)
-                else:
-                    logger.warning("Due to the limited entangler_map,"
-                                   " {} is skipped.".format(pauli))
-        logger.info("Pauli terms include: {}".format(final_paulis))
-        return final_paulis
-
-    def _extract_data_for_rotation(self, pauli, x):
-        where_non_i = np.where(np.asarray(list(pauli)) != 'I')[0]
-        return x[where_non_i]
-
-    def _construct_circuit_with_template(self, x):
-        coeffs = [self._data_map_func(self._extract_data_for_rotation(pauli, x))
-                  for pauli in self._pauli_strings] * self._depth
-        qc = copy.deepcopy(self._circuit_template)
-        data_idx = 0
-        for key, value in self._param_pos.items():
-            new_param = coeffs[data_idx]
-            for pos in value:
-                qc.data[key].param[pos] = 2 * new_param
-            data_idx += 1
-
-        return qc
-
-    def construct_circuit(self, x, qr=None, inverse=False):
-        """
-        Construct the second order expansion based on given data.
-
-        Args:
-            x (numpy.ndarray): 1-D to-be-transformed data.
-            qr (QauntumRegister): the QuantumRegister object for the circuit, if None,
-                                  generate new registers with name q.
-            inverse (bool): whether or not inverse the circuit
-
-        Returns:
-            QuantumCircuit: a quantum circuit transform data x.
-        """
-        if not isinstance(x, np.ndarray):
-            raise TypeError("x must be numpy array.")
-        if x.ndim != 1:
-            raise ValueError("x must be 1-D array.")
-        if x.shape[0] != self._num_qubits:
-            raise ValueError("number of qubits and data dimension must be the same.")
-
-        if qr is None:
-            qc = self._construct_circuit_with_template(x)
-        else:
-            qc = QuantumCircuit(qr)
-            for i in range(self._num_qubits):
-                qc.u2(0, pi, qr[i])
-            for pauli in self._pauli_strings:
-                coeff = self._data_map_func(self._extract_data_for_rotation(pauli, x))
-                p = label_to_pauli(pauli)
-                qc += Operator.construct_evolution_circuit([[coeff, p]], 1, 1, qr)
-            qc.data *= self._depth
-
-        if inverse:
-            qc.data = [gate.inverse() for gate in reversed(qc.data)]
-        return qc
+            pauli_string.append('Z' * i)
+        super().init_args(num_qubits, depth, entangler_map, entanglement,
+                          pauli_string, data_map_func)

--- a/qiskit_aqua/algorithms/components/feature_maps/pauli_z_expansion.py
+++ b/qiskit_aqua/algorithms/components/feature_maps/pauli_z_expansion.py
@@ -22,7 +22,6 @@ feature map. Several types of commonly used approaches.
 from collections import OrderedDict
 import copy
 import itertools
-import functools
 import logging
 
 import numpy as np
@@ -33,22 +32,16 @@ from sympy.core.numbers import NaN
 
 from qiskit_aqua import Operator
 from qiskit_aqua.algorithms.components.feature_maps import FeatureMap
+from qiskit_aqua.algorithms.components.feature_maps import self_product
 
 logger = logging.getLogger(__name__)
-
-
-def _data_map_func(pauli, x):
-    # coeff for the rotation angle
-    where_non_i = np.where(np.asarray(list(pauli)) != 'I')[0]
-    coeff = x[where_non_i][0] if len(where_non_i) == 1 else \
-        functools.reduce(lambda m, n: (np.pi - m) * (np.pi - n), x[where_non_i])
-    return coeff
 
 
 class PauliZExpansion(FeatureMap):
     """
     Mapping data with the second order expansion followed by entangling gates.
     Refer to https://arxiv.org/pdf/1804.11326.pdf for details.
+
     """
 
     PAULI_Z_EXPANSION_CONFIGURATION = {
@@ -91,15 +84,16 @@ class PauliZExpansion(FeatureMap):
         self._ret = {}
 
     def init_args(self, num_qubits, depth, entangler_map=None,
-                  entanglement='full', z_order=1, data_map_func=_data_map_func):
+                  entanglement='full', z_order=1, data_map_func=self_product):
         """Initializer.
 
         Args:
             num_qubits (int): number of qubits
             depth (int): the number of repeated circuits
-            entangler_map (dict):
-            entanglement (str): ['full', 'linear']
-            z_order (int): the order of Z expansion
+            entangler_map (dict): describe the connectivity of qubits
+            entanglement (str): ['full', 'linear'], generate the qubit connectivitiy by predefined
+                                topology
+            z_order (str): z order
             data_map_func (Callable): a mapping function for data x
         """
         self._num_qubits = num_qubits
@@ -121,7 +115,6 @@ class PauliZExpansion(FeatureMap):
         self._circuit_template = self._build_circuit_template()
 
     def _build_circuit_template(self):
-
         x = np.asarray([self._magic_num] * self._num_qubits)
         qr = QuantumRegister(self._num_qubits, name='q')
         qc = self.construct_circuit(x, qr)
@@ -166,18 +159,24 @@ class PauliZExpansion(FeatureMap):
                 if is_valid:
                     final_paulis.append(pauli)
                 else:
-                    logger.warning("Due to the limited entangler_map, {} is skipped.".format(pauli))
+                    logger.warning("Due to the limited entangler_map,"
+                                   " {} is skipped.".format(pauli))
         logger.info("Pauli terms include: {}".format(final_paulis))
         return final_paulis
 
+    def _extract_data_for_rotation(self, pauli, x):
+        where_non_i = np.where(np.asarray(list(pauli)) != 'I')[0]
+        return x[where_non_i]
+
     def _construct_circuit_with_template(self, x):
-        coeffs = [self._data_map_func(pauli, x) for pauli in self._pauli_strings] * self._depth
+        coeffs = [self._data_map_func(self._extract_data_for_rotation(pauli, x))
+                  for pauli in self._pauli_strings] * self._depth
         qc = copy.deepcopy(self._circuit_template)
         data_idx = 0
         for key, value in self._param_pos.items():
             new_param = coeffs[data_idx]
             for pos in value:
-                qc.data[key].param[pos] = new_param
+                qc.data[key].param[pos] = 2 * new_param
             data_idx += 1
 
         return qc
@@ -209,7 +208,7 @@ class PauliZExpansion(FeatureMap):
             for i in range(self._num_qubits):
                 qc.u2(0, pi, qr[i])
             for pauli in self._pauli_strings:
-                coeff = self._data_map_func(pauli, x)
+                coeff = self._data_map_func(self._extract_data_for_rotation(pauli, x))
                 p = label_to_pauli(pauli)
                 qc += Operator.construct_evolution_circuit([[coeff, p]], 1, 1, qr)
             qc.data *= self._depth

--- a/qiskit_aqua/algorithms/components/feature_maps/pauli_z_expansion.py
+++ b/qiskit_aqua/algorithms/components/feature_maps/pauli_z_expansion.py
@@ -19,6 +19,8 @@ This module contains the definition of a base class for
 feature map. Several types of commonly used approaches.
 """
 
+from collections import OrderedDict
+import copy
 import itertools
 import functools
 import logging
@@ -26,11 +28,21 @@ import logging
 import numpy as np
 from qiskit import QuantumCircuit, QuantumRegister
 from qiskit.tools.qi.pauli import label_to_pauli
+from qiskit.qasm import pi
+from sympy.core.numbers import NaN
 
 from qiskit_aqua import Operator
 from qiskit_aqua.algorithms.components.feature_maps import FeatureMap
 
 logger = logging.getLogger(__name__)
+
+
+def _data_map_func(pauli, x):
+    # coeff for the rotation angle
+    where_non_i = np.where(np.asarray(list(pauli)) != 'I')[0]
+    coeff = x[where_non_i][0] if len(where_non_i) == 1 else \
+        functools.reduce(lambda m, n: (np.pi - m) * (np.pi - n), x[where_non_i])
+    return coeff
 
 
 class PauliZExpansion(FeatureMap):
@@ -74,10 +86,12 @@ class PauliZExpansion(FeatureMap):
     }
 
     def __init__(self, configuration=None):
+        """Constructor."""
         super().__init__(configuration or self.PAULI_Z_EXPANSION_CONFIGURATION.copy())
         self._ret = {}
 
-    def init_args(self, num_qubits, depth, entangler_map=None, entanglement='full', z_order=1):
+    def init_args(self, num_qubits, depth, entangler_map=None,
+                  entanglement='full', z_order=1, data_map_func=_data_map_func):
         """Initializer.
 
         Args:
@@ -86,6 +100,7 @@ class PauliZExpansion(FeatureMap):
             entangler_map (dict):
             entanglement (str): ['full', 'linear']
             z_order (int): the order of Z expansion
+            data_map_func (Callable): a mapping function for data x
         """
         self._num_qubits = num_qubits
         self._depth = depth
@@ -99,6 +114,27 @@ class PauliZExpansion(FeatureMap):
                            "be changed to the number of qubits then.".format(z_order, num_qubits))
             z_order = num_qubits
         self._pauli_strings = self._build_subset_paulis_string(z_order)
+        self._data_map_func = data_map_func
+
+        self._magic_num = np.nan
+        self._param_pos = OrderedDict()
+        self._circuit_template = self._build_circuit_template()
+
+    def _build_circuit_template(self):
+
+        x = np.asarray([self._magic_num] * self._num_qubits)
+        qr = QuantumRegister(self._num_qubits, name='q')
+        qc = self.construct_circuit(x, qr)
+
+        for index in range(len(qc.data)):
+            gate_param = qc.data[index].param
+            param_sub_pos = []
+            for x in range(len(gate_param)):
+                if isinstance(gate_param[x], NaN):
+                    param_sub_pos.append(x)
+            if param_sub_pos != []:
+                self._param_pos[index] = param_sub_pos
+        return qc
 
     def _build_subset_paulis_string(self, z_order):
         temp_paulis = []
@@ -134,6 +170,18 @@ class PauliZExpansion(FeatureMap):
         logger.info("Pauli terms include: {}".format(final_paulis))
         return final_paulis
 
+    def _construct_circuit_with_template(self, x):
+        coeffs = [self._data_map_func(pauli, x) for pauli in self._pauli_strings] * self._depth
+        qc = copy.deepcopy(self._circuit_template)
+        data_idx = 0
+        for key, value in self._param_pos.items():
+            new_param = coeffs[data_idx]
+            for pos in value:
+                qc.data[key].param[pos] = new_param
+            data_idx += 1
+
+        return qc
+
     def construct_circuit(self, x, qr=None, inverse=False):
         """
         Construct the second order expansion based on given data.
@@ -147,7 +195,6 @@ class PauliZExpansion(FeatureMap):
         Returns:
             QuantumCircuit: a quantum circuit transform data x.
         """
-
         if not isinstance(x, np.ndarray):
             raise TypeError("x must be numpy array.")
         if x.ndim != 1:
@@ -155,25 +202,18 @@ class PauliZExpansion(FeatureMap):
         if x.shape[0] != self._num_qubits:
             raise ValueError("number of qubits and data dimension must be the same.")
 
-        def get_coeff(paulis):
-            # coeff for the rotation angle
-            where_non_i = np.where(np.asarray(list(paulis)) != 'I')[0]
-            coeff = x[where_non_i][0] if len(where_non_i) == 1 else \
-                functools.reduce(lambda m, n: (np.pi - m) * (np.pi - n), x[where_non_i])
-            return coeff
-
         if qr is None:
-            qr = QuantumRegister(self._num_qubits, name='q')
-        qc = QuantumCircuit(qr)
+            qc = self._construct_circuit_with_template(x)
+        else:
+            qc = QuantumCircuit(qr)
+            for i in range(self._num_qubits):
+                qc.u2(0, pi, qr[i])
+            for pauli in self._pauli_strings:
+                coeff = self._data_map_func(pauli, x)
+                p = label_to_pauli(pauli)
+                qc += Operator.construct_evolution_circuit([[coeff, p]], 1, 1, qr)
+            qc.data *= self._depth
 
-        for i in range(self._num_qubits):
-            qc.u2(0, np.pi, qr[i])
-        for pauli in self._pauli_strings:
-            coeff = get_coeff(pauli)
-            p = label_to_pauli(pauli)
-            qc += Operator.construct_evolution_circuit([[coeff, p]], 1, 1, qr)
-
-        qc.data *= self._depth
         if inverse:
             qc.data = [gate.inverse() for gate in reversed(qc.data)]
         return qc

--- a/qiskit_aqua/algorithms/components/feature_maps/pauli_z_expansion.py
+++ b/qiskit_aqua/algorithms/components/feature_maps/pauli_z_expansion.py
@@ -70,7 +70,7 @@ class PauliZExpansion(PauliExpansion):
         self._ret = {}
 
     def init_args(self, num_qubits, depth, entangler_map=None,
-                  entanglement='full', z_order=1, data_map_func=self_product):
+                  entanglement='full', z_order=2, data_map_func=self_product):
         """Initializer.
 
         Args:

--- a/qiskit_aqua/algorithms/components/feature_maps/second_order_expansion.py
+++ b/qiskit_aqua/algorithms/components/feature_maps/second_order_expansion.py
@@ -19,11 +19,11 @@ This module contains the definition of a base class for
 feature map. Several types of commonly used approaches.
 """
 
-from qiskit_aqua.algorithms.components.feature_maps.pauli_expansion import PauliExpansion
+from qiskit_aqua.algorithms.components.feature_maps.pauli_z_expansion import PauliZExpansion
 from qiskit_aqua.algorithms.components.feature_maps import self_product
 
 
-class SecondOrderExpansion(PauliExpansion):
+class SecondOrderExpansion(PauliZExpansion):
     """
     Mapping data with the second order expansion followed by entangling gates.
     Refer to https://arxiv.org/pdf/1804.11326.pdf for details.
@@ -76,4 +76,4 @@ class SecondOrderExpansion(PauliExpansion):
             data_map_func (Callable): a mapping function for data x
         """
         super().init_args(num_qubits, depth, entangler_map, entanglement,
-                          paulis=['Z', 'ZZ'], data_map_func=data_map_func)
+                          z_order=2, data_map_func=data_map_func)

--- a/qiskit_aqua/algorithms/components/feature_maps/second_order_expansion.py
+++ b/qiskit_aqua/algorithms/components/feature_maps/second_order_expansion.py
@@ -25,6 +25,7 @@ from qiskit import CompositeGate, QuantumCircuit, QuantumRegister
 from qiskit.extensions.standard.cx import CnotGate
 from qiskit.extensions.standard.u1 import U1Gate
 from qiskit.extensions.standard.u2 import U2Gate
+from qiskit.qasm import pi
 
 from qiskit_aqua.algorithms.components.feature_maps import FeatureMap
 
@@ -65,10 +66,20 @@ class SecondOrderExpansion(FeatureMap):
     }
 
     def __init__(self, configuration=None):
+        """Constructor."""
         super().__init__(configuration or self.SECOND_ORDER_EXPANSION_CONFIGURATION.copy())
         self._ret = {}
 
     def init_args(self, num_qubits, depth, entangler_map=None, entanglement='full'):
+        """Initializer.
+
+        Args:
+            num_qubits (int): number of qubits
+            depth (int): the number of repeated circuits
+            entangler_map (dict): describe the connectivity of qubits
+            entanglement (str): ['full', 'linear'], generate the qubit connectivitiy by predefined
+                                topology
+        """
         self._num_qubits = num_qubits
         self._depth = depth
         if entangler_map is None:
@@ -82,7 +93,7 @@ class SecondOrderExpansion(FeatureMap):
 
         for _ in range(self._depth):
             for i in range(x.shape[0]):
-                composite_gate._attach(U2Gate(0, np.pi, qr[i]))
+                composite_gate._attach(U2Gate(0, pi, qr[i]))
                 composite_gate._attach(U1Gate(2 * x[i], qr[i]))
             for src, targs in self._entangler_map.items():
                 for targ in targs:

--- a/qiskit_aqua/algorithms/single_sample/iqpe/iqpe.py
+++ b/qiskit_aqua/algorithms/single_sample/iqpe/iqpe.py
@@ -162,7 +162,7 @@ class IQPE(QuantumAlgorithm):
         # hadamard on a[0]
         qc.u2(0, np.pi, a[0])
         # controlled-U
-        qc.data += self._operator.construct_evolution_circuit(
+        qc.data += Operator.construct_evolution_circuit(
             slice_pauli_list, -2 * np.pi, self._num_time_slices, q, a, unitary_power=2 ** (k - 1)
         ).data
         # global phase due to identity pauli

--- a/qiskit_aqua/algorithms/single_sample/qpe/qpe.py
+++ b/qiskit_aqua/algorithms/single_sample/qpe/qpe.py
@@ -191,7 +191,7 @@ class QPE(QuantumAlgorithm):
             else:
                 raise ValueError('Unrecognized expansion mode {}.'.format(self._expansion_mode))
         for i in range(self._num_ancillae):
-            qc.data += self._operator.construct_evolution_circuit(
+            qc.data += Operator.construct_evolution_circuit(
                 slice_pauli_list, -2 * np.pi, self._num_time_slices, q, a, ctl_idx=i
             ).data
             # global phase shift for the ancilla due to the identity pauli term

--- a/qiskit_aqua/operator.py
+++ b/qiskit_aqua/operator.py
@@ -768,7 +768,7 @@ class Operator(object):
                 self.MAX_CIRCUITS_PER_JOB = sys.maxsize
             except KeyError:
                 pass
-           
+
             if "statevector" in backend:
                 execute_config['shots'] = 1
                 avg = self._eval_with_statevector(operator_mode, input_circuit, backend, execute_config)
@@ -1122,7 +1122,8 @@ class Operator(object):
         else:
             raise ValueError('Unrecognized grouping {}.'.format(grouping))
 
-    def construct_evolution_circuit(self, slice_pauli_list, evo_time, num_time_slices, state_registers,
+    @staticmethod
+    def construct_evolution_circuit(slice_pauli_list, evo_time, num_time_slices, state_registers,
                                     ancillary_registers=None, ctl_idx=0, unitary_power=None, use_basis_gates=True):
         """
         Construct the evolution circuit according to the supplied specification.
@@ -1144,7 +1145,6 @@ class Operator(object):
         if state_registers is None:
             raise ValueError('Quantum state registers are required.')
 
-        n_qubits = self.num_qubits
         qc = QuantumCircuit(state_registers)
         if ancillary_registers is not None:
             qc.add(ancillary_registers)
@@ -1155,6 +1155,7 @@ class Operator(object):
         top_XYZ_pauli_indices = [-1] * len(slice_pauli_list)
 
         for pauli_idx, pauli in enumerate(reversed(slice_pauli_list)):
+            n_qubits = pauli[1].numberofqubits
             # changes bases if necessary
             nontrivial_pauli_indices = []
             for qubit_idx in range(n_qubits):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 qiskit>=0.6.1,<0.7
 scipy>=0.19,!=0.19.1
+sympy>=1.1.1
 numpy>=1.13
 psutil>=5
 jsonschema>=2.6,<2.7


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Support general pauli-type feature map, like ZZ, XY, ZZY, etc.
resolve #146 


### Details and comments
The pauli z expansion supports any order of Z expansion, including the first and the second order expansion in the Aqua. 
E.g., 
- The first order expansion: z_order = 1
- The second order expansion: z_order = 2

The pauli expansion is more general implementation, it takes one or more pauli strings and implements them one by one in order.
E.g.
- The first order expansion: pauli string = ['Z']
- The second order expansion: pauli string = ['Z'], ['ZZ']

The coefficient before the pauli term is the product of `(pi - xi)`, xi is the i-th element of data x; however, for single qubit term, the coefficient will be xi directly. (see `self_product` function)

Note that if the provided entanlger map can not implement the desired pauli term, that pauli term will be skipped.

One more improvement we can do is how to calculate the coefficient before the pauli term.