### PR TITLE
unified the setup for running job on backend.

### DIFF
--- a/qiskit_aqua/operator.py
+++ b/qiskit_aqua/operator.py
@@ -39,8 +39,6 @@ logger = logging.getLogger(__name__)
 
 class Operator(object):
 
-    MAX_CIRCUITS_PER_JOB = 300
-
     """
     Operators relevant for quantum applications
 
@@ -566,7 +564,6 @@ class Operator(object):
                 self._to_dia_matrix(mode='matrix')
 
             result = run_circuits(input_circuit, backend=backend, execute_config=execute_config,
-                                  max_circuits_per_job=self.MAX_CIRCUITS_PER_JOB,
                                   show_circuit_summary=self._summarize_circuits)
             quantum_state = np.asarray(result.get_statevector(input_circuit))
 
@@ -580,7 +577,6 @@ class Operator(object):
             n_qubits = self.num_qubits
 
             result = run_circuits(input_circuit, backend=backend, execute_config=execute_config,
-                                  max_circuits_per_job=self.MAX_CIRCUITS_PER_JOB,
                                   show_circuit_summary=self._summarize_circuits)
             simulator_initial_state = np.asarray(result.get_statevector(input_circuit))
 
@@ -614,7 +610,6 @@ class Operator(object):
                     circuits_to_simulate.append(circuit)
 
             result = run_circuits(circuits_to_simulate, backend=backend, execute_config=temp_config,
-                                  max_circuits_per_job=self.MAX_CIRCUITS_PER_JOB,
                                   show_circuit_summary=self._summarize_circuits)
 
             for idx, pauli in enumerate(self._paulis):
@@ -674,8 +669,7 @@ class Operator(object):
                 circuits.append(circuit)
 
             result = run_circuits(circuits, backend=backend, execute_config=execute_config,
-                                  qjob_config=qjob_config, max_circuits_per_job=self.MAX_CIRCUITS_PER_JOB,
-                                  show_circuit_summary=self._summarize_circuits)
+                                  qjob_config=qjob_config, show_circuit_summary=self._summarize_circuits)
 
             avg_paulis = []
             for idx, pauli in enumerate(self._paulis):
@@ -705,8 +699,7 @@ class Operator(object):
 
             # Execute all the stacked quantum circuits - one for each TPB set
             result = run_circuits(circuits, backend=backend, execute_config=execute_config,
-                                  qjob_config=qjob_config, max_circuits_per_job=self.MAX_CIRCUITS_PER_JOB,
-                                  show_circuit_summary=self._summarize_circuits)
+                                  qjob_config=qjob_config, show_circuit_summary=self._summarize_circuits)
 
             for tpb_idx, tpb_set in enumerate(self._grouped_paulis):
                 avg_paulis = []
@@ -763,12 +756,6 @@ class Operator(object):
             avg = self._eval_directly(input_circuit)
             std_dev = 0.0
         else:
-            try:
-                qiskit.Aer.get_backend(backend)
-                self.MAX_CIRCUITS_PER_JOB = sys.maxsize
-            except KeyError:
-                pass
-           
             if "statevector" in backend:
                 execute_config['shots'] = 1
                 avg = self._eval_with_statevector(operator_mode, input_circuit, backend, execute_config)

--- a/qiskit_aqua/quantumalgorithm.py
+++ b/qiskit_aqua/quantumalgorithm.py
@@ -51,8 +51,6 @@ class QuantumAlgorithm(ABC):
     SECTION_KEY_FEATURE_MAP = 'feature_map'
     SECTION_KEY_MULTICLASS_EXTENSION = 'multiclass_extension'
 
-    MAX_CIRCUITS_PER_JOB = 300
-
     UNSUPPORTED_BACKENDS = [
         'unitary_simulator', 'clifford_simulator']
 
@@ -157,7 +155,6 @@ class QuantumAlgorithm(ABC):
         try:
             my_backend = qiskit.Aer.get_backend(backend)
             self._qjob_config.pop('wait', None)
-            self.MAX_CIRCUITS_PER_JOB = sys.maxsize
         except KeyError:
             my_backend = qiskit.IBMQ.get_backend(backend)
 
@@ -194,8 +191,7 @@ class QuantumAlgorithm(ABC):
             Result: Result object
         """
         result = run_circuits(circuits, self._backend, self._execute_config,
-                              self._qjob_config, max_circuits_per_job=self.MAX_CIRCUITS_PER_JOB,
-                              show_circuit_summary=self._show_circuit_summary)
+                              self._qjob_config, show_circuit_summary=self._show_circuit_summary)
         if self._show_circuit_summary:
             self.disable_circuit_summary()
 

--- a/qiskit_aqua/utils/run_circuits.py
+++ b/qiskit_aqua/utils/run_circuits.py
@@ -65,12 +65,9 @@ def run_circuits(circuits, backend, execute_config, qjob_config={},
     except KeyError:
         my_backend = qiskit.IBMQ.get_backend(backend)
 
-    if my_backend.configuration()['simulator']:
-        with_autorecover = False
-        max_circuits_per_job = sys.maxsize
-    else:
-        with_autorecover = True
-        max_circuits_per_job = MAX_CIRCUITS_PER_JOB
+    with_autorecover = False if my_backend.configuration()['simulator'] else True
+    max_circuits_per_job = sys.maxsize if my_backend.configuration()['local'] \
+        else MAX_CIRCUITS_PER_JOB
 
     qobjs = []
     jobs = []
@@ -91,8 +88,8 @@ def run_circuits(circuits, backend, execute_config, qjob_config={},
     if with_autorecover:
 
         logger.debug("There are {} circuits and they are chunked into {} chunks, "
-                    "each with {} circutis.".format(len(circuits), chunks,
-                                                    max_circuits_per_job))
+                     "each with {} circutis.".format(len(circuits), chunks,
+                                                     max_circuits_per_job))
 
         for idx in range(len(jobs)):
             job = jobs[idx]


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
There are two places to setup `MAX_CIRCUITS_PER_JOB` before; however, we can set this number based on whether or not the backend is a simulator. 

Thus, I think it will be better to set this number in the unified interface, `run_circuits.py`

