### PR TITLE
batch circuits of theta+ and theta- in spsa

### DIFF
--- a/qiskit_aqua/algorithms/adaptive/vqe/vqe.py
+++ b/qiskit_aqua/algorithms/adaptive/vqe/vqe.py
@@ -277,8 +277,11 @@ class VQE(QuantumAlgorithm):
                 logger.info('Energy evaluation {} returned {}'.format(self._eval_count, np.real(mean)))
         else:
             input_circuit = self._var_form.construct_circuit(parameters)
-            mean, std = self._operator.eval(self._operator_mode, input_circuit,
-                                            self._backend, self._execute_config, self._qjob_config)
+            circuit = self._operator.construct_evaluation_circuit(self._operator_mode,
+                                                                  input_circuit, self._backend)
+            result = self.execute(to_be_simulated_circuits)
+            mean, std = self._operator.evaluate_with_result(self._operator_mode, circuits[idx],
+                                                            self._backend, result)
             mean_energy = np.real(mean)
             self._eval_count += 1
 

--- a/qiskit_aqua/algorithms/components/initial_states/varformbased.py
+++ b/qiskit_aqua/algorithms/components/initial_states/varformbased.py
@@ -35,6 +35,6 @@ class VarFormBased:
         if mode == 'vector':
             raise RuntimeError('Initial state based on variational form does not support vector mode.')
         elif mode == 'circuit':
-            return self._var_form.construct_circuit(self._var_form_params)
+            return self._var_form.construct_circuit(self._var_form_params, q=register)
         else:
             raise ValueError('Mode should be either "vector" or "circuit"')

--- a/qiskit_aqua/algorithms/components/optimizers/optimizer.py
+++ b/qiskit_aqua/algorithms/components/optimizers/optimizer.py
@@ -72,6 +72,7 @@ class Optimizer(ABC):
         self._bounds_support_level = self._configuration['support_level']['bounds']
         self._initial_point_support_level = self._configuration['support_level']['initial_point']
         self._options = {}
+        self._batch_mode = False
 
     @property
     def configuration(self):
@@ -221,3 +222,6 @@ class Optimizer(ABC):
         """Print algorithm-specific options."""
         for name in sorted(self._options):
             logger.debug('{:s} = {:s}'.format(name, str(self._options[name])))
+
+    def set_batch_mode(self, mode):
+        self._batch_mode = mode

--- a/qiskit_aqua/algorithms/components/optimizers/spsa.py
+++ b/qiskit_aqua/algorithms/components/optimizers/spsa.py
@@ -71,10 +71,6 @@ class SPSA(Optimizer):
                 'skip_calibration': {
                     'type': 'boolean',
                     'default': False
-                },
-                'batch_circuits': {
-                    'type': 'boolean',
-                    'default': False
                 }
             },
             'additionalProperties': False
@@ -94,11 +90,10 @@ class SPSA(Optimizer):
         self._parameters = None
         self._skip_calibration = False
 
-    def init_args(self, max_trials=1000, c0=2*np.pi*0.1, c1=0.1, c2=0.602, c3=0.101, c4=0, skip_calibration=False, batch_circuits=False):
+    def init_args(self, max_trials=1000, c0=2*np.pi*0.1, c1=0.1, c2=0.602, c3=0.101, c4=0, skip_calibration=False):
         self._max_trials = max_trials
         self._parameters = np.array([c0, c1, c2, c3, c4])
         self._skip_calibration = skip_calibration
-        self._batch_circuits = batch_circuits
 
     def optimize(self, num_vars, objective_function, gradient_function=None, variable_bounds=None, initial_point=None):
 
@@ -163,7 +158,7 @@ class SPSA(Optimizer):
             theta_plus = theta + c_spsa * delta
             theta_minus = theta - c_spsa * delta
             # cost function for the two directions
-            if self._batch_circuits:
+            if self._batch_mode:
                 cost_plus, cost_minus = obj_fun(np.concatenate((theta_plus, theta_minus)))
             else:
                 cost_plus = obj_fun(theta_plus)
@@ -219,7 +214,7 @@ class SPSA(Optimizer):
             delta = 2 * np.random.randint(2, size=np.shape(initial_theta)[0]) - 1
             theta_plus = initial_theta + initial_c * delta
             theta_minus = initial_theta - initial_c * delta
-            if self._batch_circuits:
+            if self._batch_mode:
                 obj_plus, obj_minus = obj_fun(np.concatenate((theta_plus, theta_minus)))
             else:
                 obj_plus = obj_fun(theta_plus)

--- a/qiskit_aqua/algorithms/components/optimizers/spsa.py
+++ b/qiskit_aqua/algorithms/components/optimizers/spsa.py
@@ -164,7 +164,7 @@ class SPSA(Optimizer):
             theta_minus = theta - c_spsa * delta
             # cost function for the two directions
             if self._batch_circuits:
-                cost_plus, cost_minus = obj_fun([theta_plus, theta_minus])
+                cost_plus, cost_minus = obj_fun(np.concatenate((theta_plus, theta_minus)))
             else:
                 cost_plus = obj_fun(theta_plus)
                 cost_minus = obj_fun(theta_minus)
@@ -220,7 +220,7 @@ class SPSA(Optimizer):
             theta_plus = initial_theta + initial_c * delta
             theta_minus = initial_theta - initial_c * delta
             if self._batch_circuits:
-                obj_plus, obj_minus = obj_fun([theta_plus, theta_minus])
+                obj_plus, obj_minus = obj_fun(np.concatenate((theta_plus, theta_minus)))
             else:
                 obj_plus = obj_fun(theta_plus)
                 obj_minus = obj_fun(theta_minus)

--- a/qiskit_aqua/algorithms/components/optimizers/spsa.py
+++ b/qiskit_aqua/algorithms/components/optimizers/spsa.py
@@ -158,8 +158,7 @@ class SPSA(Optimizer):
             theta_plus = theta + c_spsa * delta
             theta_minus = theta - c_spsa * delta
             # cost function for the two directions
-            cost_plus = obj_fun(theta_plus)
-            cost_minus = obj_fun(theta_minus)
+            cost_plus, cost_minus = obj_fun([theta_plus, theta_minus])
             # derivative estimate
             g_spsa = (cost_plus - cost_minus) * delta / (2.0 * c_spsa)
             # updated theta
@@ -209,8 +208,9 @@ class SPSA(Optimizer):
             if i % 5 == 0:
                 logger.debug('calibration step # {} of {}'.format(str(i), str(stat)))
             delta = 2 * np.random.randint(2, size=np.shape(initial_theta)[0]) - 1
-            obj_plus = obj_fun(initial_theta + initial_c * delta)
-            obj_minus = obj_fun(initial_theta - initial_c * delta)
+            theta_plus = initial_theta + initial_c * delta
+            theta_minus = initial_theta - initial_c * delta
+            obj_plus, obj_minus = obj_fun([theta_plus, theta_minus])
             delta_obj += np.absolute(obj_plus - obj_minus) / stat
 
         self._parameters[0] = target_update * 2 / delta_obj \


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
batch the circuits for spsa. related to #159 and depend on #160 


### Details and comments

SPSA is able to bundle the circuits for theta+ and theta- into one job.

The design logic is if your objective function (like in VQE) can take multiple parameters (like for SPSA 2 parameters), the objective function will bundle the circuits into one job and execute it.  

