### PR TITLE
Improve the speed of grouped paulis conversion with numpy

### DIFF
--- a/qiskit_aqua/utils/pauligraph.py
+++ b/qiskit_aqua/utils/pauligraph.py
@@ -61,45 +61,36 @@ class PauliGraph(object):
         Returns:
             dictionary of graph connectivity with node index as key and list of neighbor as values
         """
-        #assert self.nodes is not None, "No nodes found."
-        edges = {i: [] for i in range(len(self.nodes))}
-        for i in range(len(self.nodes)):
-            nodei = self.nodes[i]
-            for j in range(i+1, len(self.nodes)):
-                nodej = self.nodes[j]
-                isCommutable = True
-                for k in range(self._nqbits):
-                    if ((nodei.v[k] == 0 and nodei.w[k] == 0) or
-                        (nodej.v[k] == 0 and nodej.w[k] == 0) or
-                            (nodei.v[k] == nodej.v[k] and nodei.w[k] == nodej.w[k])):
-                        pass
-                    else:
-                        isCommutable = False
-                        break
-                if not isCommutable:
-                    edges[i].append(j)
-                    edges[j].append(i)
+        conv = {
+            'I': 0,
+            'X': 1,
+            'Y': 2,
+            'Z': 3
+        }
+        a = np.array([[conv[e] for e in n.to_label()] for n in self.nodes], dtype=np.int8)
+        b = a[:, None]
+        c = (((a * b) * (a - b)) == 0).all(axis=2)  # i and j are commutable with TPB if c[i, j] is True
+        edges = {i: np.where(c[i] == False)[0] for i in range(len(self.nodes))}
         return edges
 
     def _coloring(self, mode="largest-degree"):
         if mode == "largest-degree":
-            degree = [(i, len(self.edges[i])) for i in range(len(self.nodes))]  # list of (nodeid, degree)
-            degree.sort(key=lambda x: x[1], reverse=True)  # sorted by largest degree
-            # -1 means not colored, 0 ... len(self.nodes)-1 is valid colored
-            color = [-1 for i in range(len(self.nodes))]
-            # coloring start
-            for nodei, _ in degree:
-                ineighbors = self.edges[nodei]  # get neighbors of nodei
-                ineighborsColors = set([color[j] for j in ineighbors if color[j] >= 0])  # get colors of ineighbors
-                for c in range(len(self.nodes)):
-                    if c not in ineighborsColors:
-                        color[nodei] = c
-                        break
-            # coloring end
-            assert (np.array(color) >= 0).all(), "Uncolored node exists!"
+            nodes = sorted(self.edges.keys(), key=lambda x: len(self.edges[x]), reverse=True)
+            # -1 means not colored; 0 ... len(self.nodes)-1 is valid colored
+            max_node = max(nodes)
+            color = np.array([-1] * (max_node + 1))
+            all_colors = np.arange(len(nodes))
+            for i in nodes:
+                neighbors = self.edges[i]
+                color_neighbors = color[neighbors]
+                color_neighbors = color_neighbors[color_neighbors >= 0]
+                mask = np.ones(len(nodes), dtype=bool)
+                mask[color_neighbors] = False
+                color[i] = np.min(all_colors[mask])
+            assert np.min(color[nodes]) >= 0, "Uncolored node exists!"
 
             # post-processing to grouped_paulis
-            maxColor = np.max(color)  # the color used is 0, 1, 2, ..., maxColor
+            maxColor = np.max(color[nodes])  # the color used is 0, 1, 2, ..., maxColor
             temp_gp = []  # list of indices of grouped paulis
             for c in range(maxColor+1):  # maxColor is included
                 temp_gp.append([i for i, icolor in enumerate(color) if icolor == c])


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

I revised the conversion of the grouped paulis using numpy.

### Details and comments

I revised `PauliGraph._create_edges` and `PauliGraph._coloring` with numpy. I tested my code with `BeH2JW.txt` of https://arxiv.org/src/1701.08213v1/anc and found that my version is 20x faster than aqua 0.3.0 and there is no change in the outputs.
See my gist for the details of the comparison https://gist.github.com/t-imamichi/f9974db6c3a9b88743b32e2a9ac19c28