### PR TITLE
Fix incorrect conda download link in install docs

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -22,7 +22,7 @@ Aqua. In addition, `Jupyter
 Notebook <https://jupyter.readthedocs.io/en/latest/install.html>`__ is
 recommended for interacting with the tutorials. For this reason, we
 recommend installing the `Anaconda
-3 <https://www.continuum.io/downloads>`__ Python distribution, as it
+3 <https://www.anaconda.com/download/>`__ Python distribution, as it
 comes with all of these dependencies pre-installed.
 
 .. seealso::


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This commit fixes a small issue in the install docs pointing to the
incorrect location to download the anaconda python distribution. This
corrects the link which was either a typo or has changed since the link
was first added.

### Details and comments

Fixes qiskit/qiskit-terra#1123