### PR TITLE
Missing `packaging` requirement in `setup.py`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,8 @@ requirements = [
     "scikit-learn",
     "cvxopt",
     "pyobjc-core; sys_platform == 'darwin'",
-    "pyobjc-framework-Cocoa; sys_platform == 'darwin'"
+    "pyobjc-framework-Cocoa; sys_platform == 'darwin'",
+    "packaging"
 ]
 
 setuptools.setup(


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Adds a missing requirement to `packaging` to `setup.py`.

### Details and comments

The package has only been added to `requirements.txt`.
