### PR TITLE
Fix pickle for pluggable classes and refactor nlopt validation check

### DIFF
--- a/qiskit_aqua/_discover.py
+++ b/qiskit_aqua/_discover.py
@@ -247,6 +247,9 @@ def register_pluggable(cls):
     return _register_pluggable(pluggable_type, cls)
 
 
+global_class = None
+
+
 def _register_pluggable(pluggable_type, cls):
     """
     Registers a pluggable class
@@ -260,6 +263,11 @@ def _register_pluggable(pluggable_type, cls):
     """
     if pluggable_type not in _REGISTERED_PLUGGABLES:
         _REGISTERED_PLUGGABLES[pluggable_type] = {}
+
+    # fix pickle problems
+    method = 'from {} import {}\nglobal global_class\nglobal_class = {}'.format(cls.__module__, cls.__qualname__, cls.__qualname__)
+    exec(method)
+    cls = global_class
 
     # Verify that the pluggable is not already registered.
     registered_classes = _REGISTERED_PLUGGABLES[pluggable_type]

--- a/qiskit_aqua/algorithms/components/optimizers/nlopts/_nloptimizer.py
+++ b/qiskit_aqua/algorithms/components/optimizers/nlopts/_nloptimizer.py
@@ -16,14 +16,27 @@
 # =============================================================================
 
 import numpy as np
-try:
-    import nlopt
-except ImportError:
-    raise ImportWarning('nlopt cannot be imported')
-
+import importlib
 import logging
 
 logger = logging.getLogger(__name__)
+
+try:
+    import nlopt
+except ImportError:
+    logger.info('nlopt is not installed. Please install it if you want to use them.')
+
+
+def check_pluggable_valid(name):
+    try:
+        spec = importlib.util.find_spec('nlopt')
+        if spec is not None:
+            return True
+    except:
+        pass
+
+    logger.info("Unable to instantiate '{}', nlopt is not installed. Please install it if you want to use them.".format(name))
+    return False
 
 
 def minimize(name, objective_function, variable_bounds=None, initial_point=None, max_evals=1000):
@@ -39,7 +52,6 @@ def minimize(name, objective_function, variable_bounds=None, initial_point=None,
     Returns:
         Solution at minimum found, value at minimum found, num evaluations performed
     """
-
     threshold = 3*np.pi
     low = [(l if l is not None else -threshold) for (l, u) in variable_bounds]
     high = [(u if u is not None else threshold) for (l, u) in variable_bounds]

--- a/qiskit_aqua/algorithms/components/optimizers/nlopts/crs.py
+++ b/qiskit_aqua/algorithms/components/optimizers/nlopts/crs.py
@@ -17,15 +17,15 @@
 
 from qiskit_aqua.algorithms.components.optimizers import Optimizer
 from ._nloptimizer import minimize
-import importlib
+from ._nloptimizer import check_pluggable_valid as check_nlopt_valid
 import logging
+
+logger = logging.getLogger(__name__)
 
 try:
     import nlopt
 except ImportError:
-    raise ImportWarning('nlopt cannot be imported')
-
-logger = logging.getLogger(__name__)
+    logger.info('nlopt is not installed. Please install it if you want to use them.')
 
 
 class CRS(Optimizer):
@@ -64,15 +64,7 @@ class CRS(Optimizer):
 
     @staticmethod
     def check_pluggable_valid():
-        try:
-            spec = importlib.util.find_spec('nlopt')
-            if spec is not None:
-                return True
-        except:
-            pass
-
-        logger.info("nlopt is not installed. Please install it if you want to use them.")
-        return False
+        return check_nlopt_valid(CRS.CONFIGURATION['name'])
 
     def optimize(self, num_vars, objective_function, gradient_function=None,
                  variable_bounds=None, initial_point=None):

--- a/qiskit_aqua/algorithms/components/optimizers/nlopts/direct_l.py
+++ b/qiskit_aqua/algorithms/components/optimizers/nlopts/direct_l.py
@@ -17,15 +17,15 @@
 
 from qiskit_aqua.algorithms.components.optimizers import Optimizer
 from ._nloptimizer import minimize
-import importlib
+from ._nloptimizer import check_pluggable_valid as check_nlopt_valid
 import logging
+
+logger = logging.getLogger(__name__)
 
 try:
     import nlopt
 except ImportError:
-    raise ImportWarning('nlopt cannot be imported')
-
-logger = logging.getLogger(__name__)
+    logger.info('nlopt is not installed. Please install it if you want to use them.')
 
 
 class DIRECT_L(Optimizer):
@@ -65,15 +65,7 @@ class DIRECT_L(Optimizer):
 
     @staticmethod
     def check_pluggable_valid():
-        try:
-            spec = importlib.util.find_spec('nlopt')
-            if spec is not None:
-                return True
-        except:
-            pass
-
-        logger.info("nlopt is not installed. Please install it if you want to use them.")
-        return False
+        return check_nlopt_valid(DIRECT_L.CONFIGURATION['name'])
 
     def optimize(self, num_vars, objective_function, gradient_function=None,
                  variable_bounds=None, initial_point=None):

--- a/qiskit_aqua/algorithms/components/optimizers/nlopts/direct_l_rand.py
+++ b/qiskit_aqua/algorithms/components/optimizers/nlopts/direct_l_rand.py
@@ -17,15 +17,15 @@
 
 from qiskit_aqua.algorithms.components.optimizers import Optimizer
 from ._nloptimizer import minimize
-import importlib
+from ._nloptimizer import check_pluggable_valid as check_nlopt_valid
 import logging
+
+logger = logging.getLogger(__name__)
 
 try:
     import nlopt
 except ImportError:
-    raise ImportWarning('nlopt cannot be imported')
-
-logger = logging.getLogger(__name__)
+    logger.info('nlopt is not installed. Please install it if you want to use them.')
 
 
 class DIRECT_L_RAND(Optimizer):
@@ -65,15 +65,7 @@ class DIRECT_L_RAND(Optimizer):
 
     @staticmethod
     def check_pluggable_valid():
-        try:
-            spec = importlib.util.find_spec('nlopt')
-            if spec is not None:
-                return True
-        except:
-            pass
-
-        logger.info("nlopt is not installed. Please install it if you want to use them.")
-        return False
+        return check_nlopt_valid(DIRECT_L_RAND.CONFIGURATION['name'])
 
     def optimize(self, num_vars, objective_function, gradient_function=None,
                  variable_bounds=None, initial_point=None):

--- a/qiskit_aqua/algorithms/components/optimizers/nlopts/esch.py
+++ b/qiskit_aqua/algorithms/components/optimizers/nlopts/esch.py
@@ -17,15 +17,15 @@
 
 from qiskit_aqua.algorithms.components.optimizers import Optimizer
 from ._nloptimizer import minimize
-import importlib
+from ._nloptimizer import check_pluggable_valid as check_nlopt_valid
 import logging
+
+logger = logging.getLogger(__name__)
 
 try:
     import nlopt
 except ImportError:
-    raise ImportWarning('nlopt cannot be imported')
-
-logger = logging.getLogger(__name__)
+    logger.info('nlopt is not installed. Please install it if you want to use them.')
 
 
 class ESCH(Optimizer):
@@ -64,15 +64,7 @@ class ESCH(Optimizer):
 
     @staticmethod
     def check_pluggable_valid():
-        try:
-            spec = importlib.util.find_spec('nlopt')
-            if spec is not None:
-                return True
-        except:
-            pass
-
-        logger.info("nlopt is not installed. Please install it if you want to use them.")
-        return False
+        return check_nlopt_valid(ESCH.CONFIGURATION['name'])
 
     def optimize(self, num_vars, objective_function, gradient_function=None,
                  variable_bounds=None, initial_point=None):

--- a/qiskit_aqua/algorithms/components/optimizers/nlopts/isres.py
+++ b/qiskit_aqua/algorithms/components/optimizers/nlopts/isres.py
@@ -17,15 +17,15 @@
 
 from qiskit_aqua.algorithms.components.optimizers import Optimizer
 from ._nloptimizer import minimize
-import importlib
+from ._nloptimizer import check_pluggable_valid as check_nlopt_valid
 import logging
+
+logger = logging.getLogger(__name__)
 
 try:
     import nlopt
 except ImportError:
-    raise ImportWarning('nlopt cannot be imported')
-
-logger = logging.getLogger(__name__)
+    logger.info('nlopt is not installed. Please install it if you want to use them.')
 
 
 class ISRES(Optimizer):
@@ -63,15 +63,7 @@ class ISRES(Optimizer):
 
     @staticmethod
     def check_pluggable_valid():
-        try:
-            spec = importlib.util.find_spec('nlopt')
-            if spec is not None:
-                return True
-        except:
-            pass
-
-        logger.info("nlopt is not installed. Please install it if you want to use them.")
-        return False
+        return check_nlopt_valid(ISRES.CONFIGURATION['name'])
 
     def optimize(self, num_vars, objective_function, gradient_function=None,
                  variable_bounds=None, initial_point=None):


### PR DESCRIPTION


<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Fix pickle of pluggable_classes accessed by name.
Refactor nlopt validation methods

### Details and comments
The following code should work now:

```
import multiprocessing
import numpy as np
from qiskit_aqua.input import EnergyInput
from qiskit_aqua import Operator
from qiskit_aqua import PluggableType, get_pluggable_class


def main():
    np.random.seed(50)
    pauli_dict = {
        'paulis': [{"coeff": {"imag": 0.0, "real": -1.052373245772859}, "label": "II"},
                   {"coeff": {"imag": 0.0, "real": 0.39793742484318045},
                       "label": "ZI"},
                   {"coeff": {"imag": 0.0, "real": -
                              0.39793742484318045}, "label": "IZ"},
                   {"coeff": {"imag": 0.0, "real": -
                              0.01128010425623538}, "label": "ZZ"},
                   {"coeff": {"imag": 0.0, "real": 0.18093119978423156}, "label": "XX"}
                   ]
    }
    algo_input = EnergyInput(Operator.load_from_dict(pauli_dict))

    pluggable_class = get_pluggable_class(PluggableType.ALGORITHM, 'ExactEigensolver')
    pluggable_instance = pluggable_class(algo_input.qubit_op, k=1, aux_operators=[])
    result = multiprocessing.Pool(1).map(pluggable_instance.__class__.run, [pluggable_instance])
    print(result)


if __name__ == '__main__':
    main()
```
