### PR TITLE
decouple quantum backend and quantum algorithm

### DIFF
--- a/docs/execution.rst
+++ b/docs/execution.rst
@@ -473,20 +473,6 @@ requires setting the following parameters too:
        provides more details on the configuration of the noise model for the backend.
 
 
--  An optional list can be supplied to setup the backend's coupling map:
-
-   .. code:: python
-
-       "coupling_map" : list
-
-   This is a Python list consisting of the directed edges, each edge ([A, B]) points qubit A can connect to qubit B.  Configuring it is optional; the default value is ``None``.
-   The following is an example of such a list that can be used:
-
-   .. code:: python
-
-      "coupling_map": [[0, 1], [0, 2], [1, 2], [3, 2], [3, 4], [4, 2]]
-
-
 -  An optional dictionary can be supplied to assign the qubit mapping:
 
    .. code:: python
@@ -501,18 +487,6 @@ requires setting the following parameters too:
 
       "initial_layout": {('qr', 0): ('q', 1), ('qr', 1): ('q', 0)}
 
--  An optional string can be supplied to the basis gates:
-
-   .. code:: python
-
-       "basis_gates" : string
-
-   This is a Python string consisting of basis gates, where are separated by comma.  Configuring it is optional; the default value is ``None``.
-   ``None`` denotes using the basis gates in the selected backend. The following is an example of such a dictionary that can be used:
-
-   .. code:: python
-
-      "basis_gates": "u1,u2,u3,cx,id"
 
 -  The maximum number of credits used per quantum job:
 

--- a/qiskit_aqua/__init__.py
+++ b/qiskit_aqua/__init__.py
@@ -27,7 +27,8 @@ from ._discover import (PluggableType,
                         register_pluggable,
                         deregister_pluggable)
 from .pluggable import Pluggable
-from .utils import cnx
+from .utils.cnx import cnx
+from .quantum_device import QuantumDevice
 from .algorithms import QuantumAlgorithm
 from .operator import Operator
 from ._aqua import run_algorithm, run_algorithm_to_json
@@ -43,8 +44,10 @@ __all__ = ['AquaError',
            'Pluggable',
            'Operator',
            'QuantumAlgorithm',
+
            'PluggableType',
            'refresh_pluggables',
+           'QuantumDevice',
            'local_pluggables_types',
            'local_pluggables',
            'get_pluggable_class',

--- a/qiskit_aqua/__init__.py
+++ b/qiskit_aqua/__init__.py
@@ -28,7 +28,7 @@ from ._discover import (PluggableType,
                         deregister_pluggable)
 from .pluggable import Pluggable
 from .utils.cnx import cnx
-from .quantum_exp_config import QuantumExpConfig
+from .quantum_instance import QuantumInstance
 from .algorithms import QuantumAlgorithm
 from .operator import Operator
 from ._aqua import run_algorithm, run_algorithm_to_json
@@ -44,10 +44,9 @@ __all__ = ['AquaError',
            'Pluggable',
            'Operator',
            'QuantumAlgorithm',
-
            'PluggableType',
            'refresh_pluggables',
-           'QuantumExpConfig',
+           'QuantumInstance',
            'local_pluggables_types',
            'local_pluggables',
            'get_pluggable_class',

--- a/qiskit_aqua/__init__.py
+++ b/qiskit_aqua/__init__.py
@@ -28,7 +28,7 @@ from ._discover import (PluggableType,
                         deregister_pluggable)
 from .pluggable import Pluggable
 from .utils.cnx import cnx
-from .quantum_device import QuantumDevice
+from .quantum_exp_config import QuantumExpConfig
 from .algorithms import QuantumAlgorithm
 from .operator import Operator
 from ._aqua import run_algorithm, run_algorithm_to_json
@@ -47,7 +47,7 @@ __all__ = ['AquaError',
 
            'PluggableType',
            'refresh_pluggables',
-           'QuantumDevice',
+           'QuantumExpConfig',
            'local_pluggables_types',
            'local_pluggables',
            'get_pluggable_class',

--- a/qiskit_aqua/_aqua.py
+++ b/qiskit_aqua/_aqua.py
@@ -70,7 +70,9 @@ def run_algorithm(params, algo_input=None, json_output=False, backend=None):
     backend_name = inputparser.get_section_property(JSONSchema.BACKEND, JSONSchema.NAME)
     if backend_name is not None:
         backend_cfg = {k: v for k, v in inputparser.get_section(JSONSchema.BACKEND).items() if k != 'name'}
-        # backend_cfg['backend'] = backend_name
+        noise_params = backend_cfg.pop('noise_params', None)
+        backend_cfg['config'] = {}
+        backend_cfg['config']['noise_params'] = noise_params
         QuantumDevice.register_and_get_operational_backends()
         try:
             backend_from_name = Aer.get_backend(backend_name)

--- a/qiskit_aqua/_aqua.py
+++ b/qiskit_aqua/_aqua.py
@@ -33,7 +33,7 @@ from qiskit_aqua._discover import (_discover_on_demand,
 from qiskit_aqua.utils.jsonutils import convert_dict_to_json, convert_json_to_dict
 from qiskit_aqua.parser._inputparser import InputParser
 from qiskit_aqua.parser import JSONSchema
-from qiskit_aqua import QuantumDevice
+from qiskit_aqua import QuantumExpConfig
 
 logger = logging.getLogger(__name__)
 
@@ -73,7 +73,7 @@ def run_algorithm(params, algo_input=None, json_output=False, backend=None):
         noise_params = backend_cfg.pop('noise_params', None)
         backend_cfg['config'] = {}
         backend_cfg['config']['noise_params'] = noise_params
-        QuantumDevice.register_and_get_operational_backends()
+        QuantumExpConfig.register_and_get_operational_backends()
         try:
             backend_from_name = Aer.get_backend(backend_name)
         except:
@@ -105,7 +105,7 @@ def run_algorithm(params, algo_input=None, json_output=False, backend=None):
         if pass_manager is not None:
             backend_cfg['pass_manager'] = pass_manager
 
-        quantum_device = QuantumDevice(**backend_cfg)
+        quantum_device = QuantumExpConfig(**backend_cfg)
 
     value = algorithm.run(quantum_device)
     if isinstance(value, dict) and json_output:

--- a/qiskit_aqua/_aqua.py
+++ b/qiskit_aqua/_aqua.py
@@ -33,7 +33,7 @@ from qiskit_aqua._discover import (_discover_on_demand,
 from qiskit_aqua.utils.jsonutils import convert_dict_to_json, convert_json_to_dict
 from qiskit_aqua.parser._inputparser import InputParser
 from qiskit_aqua.parser import JSONSchema
-from qiskit_aqua import QuantumExpConfig
+from qiskit_aqua import QuantumInstance
 
 logger = logging.getLogger(__name__)
 
@@ -73,7 +73,7 @@ def run_algorithm(params, algo_input=None, json_output=False, backend=None):
         noise_params = backend_cfg.pop('noise_params', None)
         backend_cfg['config'] = {}
         backend_cfg['config']['noise_params'] = noise_params
-        QuantumExpConfig.register_and_get_operational_backends()
+        QuantumInstance.register_and_get_operational_backends()
         try:
             backend_from_name = Aer.get_backend(backend_name)
         except:
@@ -100,7 +100,7 @@ def run_algorithm(params, algo_input=None, json_output=False, backend=None):
                                     algo_name).init_params(algo_params, algo_input)
     random_seed = inputparser.get_section_property(JSONSchema.PROBLEM, 'random_seed')
     algorithm.random_seed = random_seed
-    quantum_exp_config = None
+    quantum_instance = None
     if backend_cfg is not None:
         backend_cfg['seed'] = random_seed
         backend_cfg['seed_mapper'] = random_seed
@@ -108,9 +108,9 @@ def run_algorithm(params, algo_input=None, json_output=False, backend=None):
         if pass_manager is not None:
             backend_cfg['pass_manager'] = pass_manager
 
-        quantum_exp_config = QuantumExpConfig(**backend_cfg)
+        quantum_instance = QuantumInstance(**backend_cfg)
 
-    value = algorithm.run(quantum_exp_config)
+    value = algorithm.run(quantum_instance)
     if isinstance(value, dict) and json_output:
         convert_dict_to_json(value)
 

--- a/qiskit_aqua/_aqua.py
+++ b/qiskit_aqua/_aqua.py
@@ -97,14 +97,13 @@ def run_algorithm(params, algo_input=None, json_output=False, backend=None):
     algorithm = get_pluggable_class(PluggableType.ALGORITHM,
                                     algo_name).init_params(algo_params, algo_input)
     algorithm.random_seed = inputparser.get_section_property(JSONSchema.PROBLEM, 'random_seed')
-
+    quantum_device = None
     if backend_cfg is not None:
         pass_manager = PassManager() if backend_cfg.pop('skip_transpiler', False) else None
         if pass_manager is not None:
             backend_cfg['pass_manager'] = pass_manager
 
-    quantum_device = QuantumDevice(**backend_cfg)
-        # algorithm.setup_quantum_backend(**backend_cfg)
+        quantum_device = QuantumDevice(**backend_cfg)
 
     value = algorithm.run(quantum_device)
     if isinstance(value, dict) and json_output:

--- a/qiskit_aqua/_aqua.py
+++ b/qiskit_aqua/_aqua.py
@@ -98,16 +98,19 @@ def run_algorithm(params, algo_input=None, json_output=False, backend=None):
     algo_params = copy.deepcopy(inputparser.get_sections())
     algorithm = get_pluggable_class(PluggableType.ALGORITHM,
                                     algo_name).init_params(algo_params, algo_input)
-    algorithm.random_seed = inputparser.get_section_property(JSONSchema.PROBLEM, 'random_seed')
-    quantum_device = None
+    random_seed = inputparser.get_section_property(JSONSchema.PROBLEM, 'random_seed')
+    algorithm.random_seed = random_seed
+    quantum_exp_config = None
     if backend_cfg is not None:
+        backend_cfg['seed'] = random_seed
+        backend_cfg['seed_mapper'] = random_seed
         pass_manager = PassManager() if backend_cfg.pop('skip_transpiler', False) else None
         if pass_manager is not None:
             backend_cfg['pass_manager'] = pass_manager
 
-        quantum_device = QuantumExpConfig(**backend_cfg)
+        quantum_exp_config = QuantumExpConfig(**backend_cfg)
 
-    value = algorithm.run(quantum_device)
+    value = algorithm.run(quantum_exp_config)
     if isinstance(value, dict) and json_output:
         convert_dict_to_json(value)
 

--- a/qiskit_aqua/algorithms/adaptive/qsvm/cost_helpers.py
+++ b/qiskit_aqua/algorithms/adaptive/qsvm/cost_helpers.py
@@ -61,7 +61,7 @@ def assign_label(measured_key, num_classes):
         return key_order if key_order < num_classes else num_classes - 1
 
 
-def cost_estimate(shots, probs, gt_labels):
+def cost_estimate(probs, gt_labels, shots=None):
     """Calculate cross entropy
     # shots is kept since it may be needed in future.
     Args:

--- a/qiskit_aqua/algorithms/adaptive/qsvm/qsvm_variational.py
+++ b/qiskit_aqua/algorithms/adaptive/qsvm/qsvm_variational.py
@@ -188,9 +188,9 @@ class QSVMVariational(QuantumAlgorithm):
             numpy.ndarray or [numpy.ndarray]: list of NxK array
             numpy.ndarray or [numpy.ndarray]: list of Nx1 array
         """
-        if self._quantum_exp_config.is_statevector:
+        if self._quantum_instance.is_statevector:
             raise ValueError('Selected backend "{}" is not supported.'.format(
-                self._quantum_exp_config.backend_name))
+                self._quantum_instance.backend_name))
 
         predicted_probs = []
         predicted_labels = []
@@ -206,7 +206,7 @@ class QSVMVariational(QuantumAlgorithm):
                 circuits[circuit_id] = circuit
                 circuit_id += 1
 
-        results = self._quantum_exp_config.execute(list(circuits.values()))
+        results = self._quantum_instance.execute(list(circuits.values()))
 
         circuit_id = 0
         predicted_probs = []
@@ -227,15 +227,15 @@ class QSVMVariational(QuantumAlgorithm):
 
         return predicted_probs, predicted_labels
 
-    def train(self, data, labels, quantum_device=None):
+    def train(self, data, labels, quantum_instance=None):
         """Train the models, and save results.
 
         Args:
             data (numpy.ndarray): NxD array, N is number of data and D is dimension
             labels (numpy.ndarray): Nx1 array, N is number of data
-            quantum_device (QuantumExpConfig): quantum backend with all setting
+            quantum_instance (QuantumInstance): quantum backend with all setting
         """
-        self._quantum_exp_config = self._quantum_exp_config if quantum_device is None else quantum_device
+        self._quantum_instance = self._quantum_instance if quantum_instance is None else quantum_instance
 
         def _cost_function_wrapper(theta):
             predicted_probs, predicted_labels = self._get_prediction(data, theta)
@@ -256,17 +256,17 @@ class QSVMVariational(QuantumAlgorithm):
         self._ret['opt_params'] = theta_best
         self._ret['training_loss'] = cost_final
 
-    def test(self, data, labels, quantum_device=None):
+    def test(self, data, labels, quantum_instance=None):
         """Predict the labels for the data, and test against with ground truth labels.
 
         Args:
             data (numpy.ndarray): NxD array, N is number of data and D is data dimension
             labels (numpy.ndarray): Nx1 array, N is number of data
-            quantum_device (QuantumExpConfig): quantum backend with all setting
+            quantum_instance (QuantumInstance): quantum backend with all setting
         Returns:
             float: classification accuracy
         """
-        self._quantum_exp_config = self._quantum_exp_config if quantum_device is None else quantum_device
+        self._quantum_instance = self._quantum_instance if quantum_instance is None else quantum_instance
         predicted_probs, predicted_labels = self._get_prediction(data, self._ret['opt_params'])
         total_cost = self._cost_function(predicted_probs, labels)
         accuracy = np.sum((np.argmax(predicted_probs, axis=1) == labels)) / labels.shape[0]
@@ -276,17 +276,17 @@ class QSVMVariational(QuantumAlgorithm):
         self._ret['testing_loss'] = total_cost
         return accuracy
 
-    def predict(self, data, quantum_device=None):
+    def predict(self, data, quantum_instance=None):
         """Predict the labels for the data.
 
         Args:
             data (numpy.ndarray): NxD array, N is number of data, D is data dimension
-            quantum_device (QuantumExpConfig): quantum backend with all setting
+            quantum_instance (QuantumInstance): quantum backend with all setting
         Returns:
             [dict]: for each data point, generates the predicted probability for each class
             list: for each data point, generates the predicted label, which with the highest prob
         """
-        self._quantum_exp_config = self._quantum_exp_config if quantum_device is None else quantum_device
+        self._quantum_instance = self._quantum_instance if quantum_instance is None else quantum_instance
         predicted_probs, predicted_labels = self._get_prediction(data, self._ret['opt_params'])
         self._ret['predicted_probs'] = predicted_probs
         self._ret['predicted_labels'] = predicted_labels

--- a/qiskit_aqua/algorithms/adaptive/qsvm/qsvm_variational.py
+++ b/qiskit_aqua/algorithms/adaptive/qsvm/qsvm_variational.py
@@ -188,9 +188,9 @@ class QSVMVariational(QuantumAlgorithm):
             numpy.ndarray or [numpy.ndarray]: list of NxK array
             numpy.ndarray or [numpy.ndarray]: list of Nx1 array
         """
-        if self._quantum_device.is_statevector:
+        if self._quantum_exp_config.is_statevector:
             raise ValueError('Selected backend "{}" is not supported.'.format(
-                self._quantum_device.backend_name))
+                self._quantum_exp_config.backend_name))
 
         predicted_probs = []
         predicted_labels = []
@@ -206,7 +206,7 @@ class QSVMVariational(QuantumAlgorithm):
                 circuits[circuit_id] = circuit
                 circuit_id += 1
 
-        results = self._quantum_device.execute(list(circuits.values()))
+        results = self._quantum_exp_config.execute(list(circuits.values()))
 
         circuit_id = 0
         predicted_probs = []
@@ -233,9 +233,9 @@ class QSVMVariational(QuantumAlgorithm):
         Args:
             data (numpy.ndarray): NxD array, N is number of data and D is dimension
             labels (numpy.ndarray): Nx1 array, N is number of data
-            quantum_device (QuantumDevice): quantum backend with all setting
+            quantum_device (QuantumExpConfig): quantum backend with all setting
         """
-        self._quantum_device = self._quantum_device if quantum_device is None else quantum_device
+        self._quantum_exp_config = self._quantum_exp_config if quantum_device is None else quantum_device
 
         def _cost_function_wrapper(theta):
             predicted_probs, predicted_labels = self._get_prediction(data, theta)
@@ -262,11 +262,11 @@ class QSVMVariational(QuantumAlgorithm):
         Args:
             data (numpy.ndarray): NxD array, N is number of data and D is data dimension
             labels (numpy.ndarray): Nx1 array, N is number of data
-            quantum_device (QuantumDevice): quantum backend with all setting
+            quantum_device (QuantumExpConfig): quantum backend with all setting
         Returns:
             float: classification accuracy
         """
-        self._quantum_device = self._quantum_device if quantum_device is None else quantum_device
+        self._quantum_exp_config = self._quantum_exp_config if quantum_device is None else quantum_device
         predicted_probs, predicted_labels = self._get_prediction(data, self._ret['opt_params'])
         total_cost = self._cost_function(predicted_probs, labels)
         accuracy = np.sum((np.argmax(predicted_probs, axis=1) == labels)) / labels.shape[0]
@@ -281,12 +281,12 @@ class QSVMVariational(QuantumAlgorithm):
 
         Args:
             data (numpy.ndarray): NxD array, N is number of data, D is data dimension
-            quantum_device (QuantumDevice): quantum backend with all setting
+            quantum_device (QuantumExpConfig): quantum backend with all setting
         Returns:
             [dict]: for each data point, generates the predicted probability for each class
             list: for each data point, generates the predicted label, which with the highest prob
         """
-        self._quantum_device = self._quantum_device if quantum_device is None else quantum_device
+        self._quantum_exp_config = self._quantum_exp_config if quantum_device is None else quantum_device
         predicted_probs, predicted_labels = self._get_prediction(data, self._ret['opt_params'])
         self._ret['predicted_probs'] = predicted_probs
         self._ret['predicted_labels'] = predicted_labels

--- a/qiskit_aqua/algorithms/adaptive/vqe/vqe.py
+++ b/qiskit_aqua/algorithms/adaptive/vqe/vqe.py
@@ -249,7 +249,7 @@ class VQE(QuantumAlgorithm):
 
     def _run(self):
         """
-        Runs the algorithm to compute the minimum eigenvalue.
+        Run the algorithm to compute the minimum eigenvalue.
 
         Returns:
             Dictionary of results

--- a/qiskit_aqua/algorithms/adaptive/vqe/vqe.py
+++ b/qiskit_aqua/algorithms/adaptive/vqe/vqe.py
@@ -201,7 +201,7 @@ class VQE(QuantumAlgorithm):
         """
         input_circuit = self._var_form.construct_circuit(parameter)
         circuit = self._operator.construct_evaluation_circuit(self._operator_mode,
-                                                              input_circuit, self._quantum_device.backend)
+                                                              input_circuit, self._quantum_exp_config.backend)
         return circuit
 
     def _solve(self):
@@ -209,8 +209,8 @@ class VQE(QuantumAlgorithm):
         self._ret['eigvals'] = np.asarray([opt_val])
         self._ret['opt_params'] = opt_params
         qc = self._var_form.construct_circuit(self._ret['opt_params'])
-        if self._quantum_device.is_statevector:
-            ret = self._quantum_device.execute(qc)
+        if self._quantum_exp_config.is_statevector:
+            ret = self._quantum_exp_config.execute(qc)
             self._ret['eigvecs'] = np.asarray([ret.get_statevector(qc, decimals=16)])
         else:
             c = ClassicalRegister(self._operator.num_qubits, name='c')
@@ -218,7 +218,7 @@ class VQE(QuantumAlgorithm):
             qc.add_register(c)
             qc.barrier(q)
             qc.measure(q, c)
-            ret = self._quantum_device.execute(qc)
+            ret = self._quantum_exp_config.execute(qc)
             self._ret['eigvecs'] = np.asarray([ret.get_counts(qc)])
 
     def _get_ground_state_energy(self):
@@ -235,10 +235,10 @@ class VQE(QuantumAlgorithm):
             mean, std = 0.0, 0.0
             if not operator.is_empty():
                 circuit = operator.construct_evaluation_circuit(self._operator_mode,
-                                                                wavefn_circuit, self._quantum_device.backend)
-                result = self._quantum_device.execute(circuit)
+                                                                wavefn_circuit, self._quantum_exp_config.backend)
+                result = self._quantum_exp_config.execute(circuit)
                 mean, std = operator.evaluate_with_result(self._operator_mode,
-                                                          circuit, self._quantum_device.backend, result)
+                                                          circuit, self._quantum_exp_config.backend, result)
                 mean = mean.real if abs(mean.real) > threshold else 0.0
                 std = std.real if abs(std.real) > threshold else 0.0
             values.append((mean, std))
@@ -254,12 +254,12 @@ class VQE(QuantumAlgorithm):
         Returns:
             Dictionary of results
         """
-        if not self._quantum_device.is_statevector and self._operator_mode == 'matrix':
+        if not self._quantum_exp_config.is_statevector and self._operator_mode == 'matrix':
             logger.warning('Qasm simulation does not work on {} mode, changing '
                            'the operator_mode to "paulis"'.format(self._operator_mode))
             self._operator_mode = 'paulis'
 
-        self._quantum_device.circuit_summary = True
+        self._quantum_exp_config.circuit_summary = True
         self._eval_count = 0
         self._solve()
         self._get_ground_state_energy()
@@ -288,12 +288,12 @@ class VQE(QuantumAlgorithm):
             circuits.append(circuit)
 
         to_be_simulated_circuits = functools.reduce(lambda x, y: x + y, circuits)
-        result = self._quantum_device.execute(to_be_simulated_circuits)
+        result = self._quantum_exp_config.execute(to_be_simulated_circuits)
         mean_energy = []
         std_energy = []
         for idx in range(len(parameter_sets)):
             mean, std = self._operator.evaluate_with_result(
-                self._operator_mode, circuits[idx], self._quantum_device.backend, result)
+                self._operator_mode, circuits[idx], self._quantum_exp_config.backend, result)
             mean_energy.append(np.real(mean))
             std_energy.append(np.real(std))
             self._eval_count += 1

--- a/qiskit_aqua/algorithms/classical/cplex/cplex_ising.py
+++ b/qiskit_aqua/algorithms/classical/cplex/cplex_ising.py
@@ -97,7 +97,7 @@ class CPLEX_Ising(QuantumAlgorithm):
         logger.info('CPLEX is not installed. See https://www.ibm.com/support/knowledgecenter/SSSA5P_12.8.0/ilog.odms.studio.help/Optimization_Studio/topics/COS_home.html')
         return False
 
-    def run(self):
+    def _run(self):
         model = IsingModel(self._ins, timelimit=self._timelimit,
                            thread=self._thread, display=self._display)
         self._sol = model.solve()

--- a/qiskit_aqua/algorithms/classical/exacteigensolver/exacteigensolver.py
+++ b/qiskit_aqua/algorithms/classical/exacteigensolver/exacteigensolver.py
@@ -131,7 +131,7 @@ class ExactEigensolver(QuantumAlgorithm):
             operator.to_matrix()
             value = 0.0
             if not operator.is_empty():
-                value, _ = operator.eval('matrix', wavefn, self._backend)
+                value, _ = operator.eval('matrix', wavefn, None)
                 value = value.real if abs(value.real) > threshold else 0.0
             values.append((value, 0))
         return np.asarray(values)

--- a/qiskit_aqua/algorithms/classical/exacteigensolver/exacteigensolver.py
+++ b/qiskit_aqua/algorithms/classical/exacteigensolver/exacteigensolver.py
@@ -136,9 +136,9 @@ class ExactEigensolver(QuantumAlgorithm):
             values.append((value, 0))
         return np.asarray(values)
 
-    def run(self):
+    def _run(self):
         """
-        Runs the algorithm to compute up to the requested k number of eigenvalues
+        Run the algorithm to compute up to the requested k number of eigenvalues.
         Returns:
             Dictionary of results
         """

--- a/qiskit_aqua/algorithms/classical/svm/svm_classical.py
+++ b/qiskit_aqua/algorithms/classical/svm/svm_classical.py
@@ -127,7 +127,7 @@ class SVM_Classical(QuantumAlgorithm):
         """
         return self.instance.predict(data)
 
-    def run(self):
+    def _run(self):
         return self.instance.run()
 
     @property

--- a/qiskit_aqua/algorithms/many_sample/eoh/eoh.py
+++ b/qiskit_aqua/algorithms/many_sample/eoh/eoh.py
@@ -159,7 +159,13 @@ class EOH(QuantumAlgorithm):
                    paulis_grouping=paulis_grouping, expansion_mode=expansion_mode,
                    expansion_order=expansion_order)
 
-    def run(self):
+    def construct_circuit(self):
+        """
+        Construct the circuit.
+
+        Returns:
+            QuantumCircuit: the circuit.
+        """
         quantum_registers = QuantumRegister(self._operator.num_qubits, name='q')
         qc = self._initial_state.construct_circuit('circuit', quantum_registers)
 
@@ -173,6 +179,13 @@ class EOH(QuantumAlgorithm):
             expansion_mode=self._expansion_mode,
             expansion_order=self._expansion_order,
         )
+
+        return qc
+
+    def run(self):
+        qc = self.construct_circuit()
+        qc_with_op = self._operator.construct_evaluation_circuit(self._operator_mode,
+                                                                 qc, self._backend)
 
         self._ret['avg'], self._ret['std_dev'] = self._operator.eval(self._operator_mode, qc, self._backend)
         return self._ret

--- a/qiskit_aqua/algorithms/many_sample/eoh/eoh.py
+++ b/qiskit_aqua/algorithms/many_sample/eoh/eoh.py
@@ -185,8 +185,8 @@ class EOH(QuantumAlgorithm):
     def _run(self):
         qc = self.construct_circuit()
         qc_with_op = self._operator.construct_evaluation_circuit(self._operator_mode,
-                                                                 qc, self._quantum_device.backend)
-        result = self._quantum_device.execute(qc_with_op)
+                                                                 qc, self._quantum_exp_config.backend)
+        result = self._quantum_exp_config.execute(qc_with_op)
         self._ret['avg'], self._ret['std_dev'] = self._operator.evaluate_with_result(self._operator_mode,
-                                                                                     qc_with_op, self._quantum_device.backend, result)
+                                                                                     qc_with_op, self._quantum_exp_config.backend, result)
         return self._ret

--- a/qiskit_aqua/algorithms/many_sample/eoh/eoh.py
+++ b/qiskit_aqua/algorithms/many_sample/eoh/eoh.py
@@ -185,8 +185,8 @@ class EOH(QuantumAlgorithm):
     def _run(self):
         qc = self.construct_circuit()
         qc_with_op = self._operator.construct_evaluation_circuit(self._operator_mode,
-                                                                 qc, self._backend)
+                                                                 qc, self._quantum_device.backend)
         result = self._quantum_device.execute(qc_with_op)
         self._ret['avg'], self._ret['std_dev'] = self._operator.evaluate_with_result(self._operator_mode,
-                                                                                     qc_with_op, self._backend, result)
+                                                                                     qc_with_op, self._quantum_device.backend, result)
         return self._ret

--- a/qiskit_aqua/algorithms/many_sample/eoh/eoh.py
+++ b/qiskit_aqua/algorithms/many_sample/eoh/eoh.py
@@ -185,8 +185,8 @@ class EOH(QuantumAlgorithm):
     def _run(self):
         qc = self.construct_circuit()
         qc_with_op = self._operator.construct_evaluation_circuit(self._operator_mode,
-                                                                 qc, self._quantum_exp_config.backend)
-        result = self._quantum_exp_config.execute(qc_with_op)
+                                                                 qc, self._quantum_instance.backend)
+        result = self._quantum_instance.execute(qc_with_op)
         self._ret['avg'], self._ret['std_dev'] = self._operator.evaluate_with_result(self._operator_mode,
-                                                                                     qc_with_op, self._quantum_exp_config.backend, result)
+                                                                                     qc_with_op, self._quantum_instance.backend, result)
         return self._ret

--- a/qiskit_aqua/algorithms/many_sample/eoh/eoh.py
+++ b/qiskit_aqua/algorithms/many_sample/eoh/eoh.py
@@ -182,10 +182,11 @@ class EOH(QuantumAlgorithm):
 
         return qc
 
-    def run(self):
+    def _run(self):
         qc = self.construct_circuit()
         qc_with_op = self._operator.construct_evaluation_circuit(self._operator_mode,
                                                                  qc, self._backend)
-
-        self._ret['avg'], self._ret['std_dev'] = self._operator.eval(self._operator_mode, qc, self._backend)
+        result = self._quantum_device.execute(qc_with_op)
+        self._ret['avg'], self._ret['std_dev'] = self._operator.evaluate_with_result(self._operator_mode,
+                                                                                     qc_with_op, self._backend, result)
         return self._ret

--- a/qiskit_aqua/algorithms/many_sample/qsvm/_qsvm_kernel_binary.py
+++ b/qiskit_aqua/algorithms/many_sample/qsvm/_qsvm_kernel_binary.py
@@ -210,7 +210,7 @@ class _QSVM_Kernel_Binary(_QSVM_Kernel_ABC):
         if self.test_dataset is not None:
             self.test(self.test_dataset[0], self.test_dataset[1])
         if self.datapoints is not None:
-            predicted_labels, _ = self.predict(self.datapoints)
+            predicted_labels = self.predict(self.datapoints)
             predicted_classes = map_label_to_class_name(predicted_labels, self.label_to_class)
             self._ret['predicted_labels'] = predicted_labels
             self._ret['predicted_classes'] = predicted_classes

--- a/qiskit_aqua/algorithms/many_sample/qsvm/_qsvm_kernel_binary.py
+++ b/qiskit_aqua/algorithms/many_sample/qsvm/_qsvm_kernel_binary.py
@@ -75,7 +75,7 @@ class _QSVM_Kernel_Binary(_QSVM_Kernel_ABC):
         else:
             is_symmetric = False
 
-        is_statevector_sim = self.qalgo.quantum_exp_config.is_statevector
+        is_statevector_sim = self.qalgo.quantum_instance.is_statevector
 
         measurement_basis = '0' * self.num_qubits
         circuits = {}
@@ -90,7 +90,7 @@ class _QSVM_Kernel_Binary(_QSVM_Kernel_ABC):
                 if circuit is not None:
                     to_be_simulated_circuits.append(circuit)
 
-        results = self.qalgo.quantum_exp_config.execute(to_be_simulated_circuits)
+        results = self.qalgo.quantum_instance.execute(to_be_simulated_circuits)
 
         # element on the diagonal is always 1: point*point=|point|^2
         if is_symmetric:
@@ -147,7 +147,7 @@ class _QSVM_Kernel_Binary(_QSVM_Kernel_ABC):
                                   D is the feature dimension.
             labels (numpy.ndarray): Nx1 array, where N is the number of data
         """
-        scaling = 1.0 if self.qalgo.quantum_exp_config.is_statevector else None
+        scaling = 1.0 if self.qalgo.quantum_instance.is_statevector else None
         kernel_matrix = self.construct_kernel_matrix(data)
         labels = labels * 2 - 1  # map label from 0 --> -1 and 1 --> 1
         labels = labels.astype(np.float)

--- a/qiskit_aqua/algorithms/many_sample/qsvm/_qsvm_kernel_binary.py
+++ b/qiskit_aqua/algorithms/many_sample/qsvm/_qsvm_kernel_binary.py
@@ -210,7 +210,7 @@ class _QSVM_Kernel_Binary(_QSVM_Kernel_ABC):
         if self.test_dataset is not None:
             self.test(self.test_dataset[0], self.test_dataset[1])
         if self.datapoints is not None:
-            predicted_labels = self.predict(self.datapoints)
+            predicted_labels, _ = self.predict(self.datapoints)
             predicted_classes = map_label_to_class_name(predicted_labels, self.label_to_class)
             self._ret['predicted_labels'] = predicted_labels
             self._ret['predicted_classes'] = predicted_classes

--- a/qiskit_aqua/algorithms/many_sample/qsvm/_qsvm_kernel_binary.py
+++ b/qiskit_aqua/algorithms/many_sample/qsvm/_qsvm_kernel_binary.py
@@ -20,7 +20,6 @@ import logging
 import numpy as np
 from qiskit import ClassicalRegister, QuantumCircuit, QuantumRegister
 
-from qiskit_aqua import QuantumAlgorithm
 from qiskit_aqua.algorithms.many_sample.qsvm._qsvm_kernel_abc import _QSVM_Kernel_ABC
 from qiskit_aqua.utils import map_label_to_class_name, optimize_svm
 
@@ -30,7 +29,7 @@ logger = logging.getLogger(__name__)
 class _QSVM_Kernel_Binary(_QSVM_Kernel_ABC):
     """The binary classifier."""
 
-    def inner_product(self, x1, x2, measurement=True):
+    def construct_circuit(self, x1, x2, measurement=False):
         """
         Generate inner product of x1 and x2 with the given feature map.
 
@@ -76,7 +75,7 @@ class _QSVM_Kernel_Binary(_QSVM_Kernel_ABC):
         else:
             is_symmetric = False
 
-        is_statevector_sim = QuantumAlgorithm.is_statevector_backend(self.qalgo.backend)
+        is_statevector_sim = self.qalgo.quantum_device.is_statevector
 
         measurement_basis = '0' * self.num_qubits
         circuits = {}
@@ -85,13 +84,13 @@ class _QSVM_Kernel_Binary(_QSVM_Kernel_ABC):
             for j in np.arange(i + 1 if is_symmetric else 0, x2_vec.shape[0]):
                 x1 = x1_vec[i]
                 x2 = x2_vec[j]
-                circuit = None if np.all(x1 == x2) else self.inner_product(x1, x2,
-                                                                           not is_statevector_sim)
+                circuit = None if np.all(x1 == x2) else self.construct_circuit(x1, x2,
+                                                                               not is_statevector_sim)
                 circuits["{}:{}".format(i, j)] = circuit
                 if circuit is not None:
                     to_be_simulated_circuits.append(circuit)
 
-        results = self.qalgo.execute(to_be_simulated_circuits)
+        results = self.qalgo.quantum_device.execute(to_be_simulated_circuits)
 
         # element on the diagonal is always 1: point*point=|point|^2
         if is_symmetric:
@@ -109,8 +108,7 @@ class _QSVM_Kernel_Binary(_QSVM_Kernel_ABC):
                     kernel_value = np.dot(temp.T.conj(), temp).real
                 else:
                     result = results.get_counts(circuit)
-                    kernel_value = result.get(measurement_basis, 0) / \
-                        self.qalgo._execute_config['shots']
+                    kernel_value = result.get(measurement_basis, 0) / sum(result.values())
             mat[i, j] = kernel_value
             if is_symmetric:
                 mat[j, i] = mat[i, j]
@@ -125,7 +123,7 @@ class _QSVM_Kernel_Binary(_QSVM_Kernel_ABC):
                                   D is the feature dimension.
         Returns:
             numpy.ndarray: Nx1 array, predicted confidence
-            numpy.ndarray: the kernel matrix, NxN1, where N1 is the number of support vectors.
+            numpy.ndarray (optional): the kernel matrix, NxN1, where N1 is the number of support vectors.
         """
         alphas = self._ret['svm']['alphas']
         bias = self._ret['svm']['bias']
@@ -149,7 +147,7 @@ class _QSVM_Kernel_Binary(_QSVM_Kernel_ABC):
                                   D is the feature dimension.
             labels (numpy.ndarray): Nx1 array, where N is the number of data
         """
-        scaling = 1.0 if QuantumAlgorithm.is_statevector_backend(self.qalgo.backend) else None
+        scaling = 1.0 if self.qalgo.quantum_device.is_statevector else None
         kernel_matrix = self.construct_kernel_matrix(data)
         labels = labels * 2 - 1  # map label from 0 --> -1 and 1 --> 1
         labels = labels.astype(np.float)
@@ -218,3 +216,18 @@ class _QSVM_Kernel_Binary(_QSVM_Kernel_ABC):
             self._ret['predicted_classes'] = predicted_classes
 
         return self._ret
+
+    def load_model(self, file_path):
+        model_npz = np.load(file_path)
+        model = {'alphas': model_npz['alphas'],
+                 'bias': model_npz['bias'],
+                 'support_vectors': model_npz['support_vectors'],
+                 'yin': model_npz['yin']}
+        self._ret['svm'] = model
+
+    def save_model(self, file_path):
+        model = {'alphas': self._ret['alphas'],
+                 'bias': self._ret['bias'],
+                 'support_vectors': self._ret['support_vectors'],
+                 'yin': self._ret['yin']}
+        np.savez(file_path, **model)

--- a/qiskit_aqua/algorithms/many_sample/qsvm/_qsvm_kernel_binary.py
+++ b/qiskit_aqua/algorithms/many_sample/qsvm/_qsvm_kernel_binary.py
@@ -75,7 +75,7 @@ class _QSVM_Kernel_Binary(_QSVM_Kernel_ABC):
         else:
             is_symmetric = False
 
-        is_statevector_sim = self.qalgo.quantum_device.is_statevector
+        is_statevector_sim = self.qalgo.quantum_exp_config.is_statevector
 
         measurement_basis = '0' * self.num_qubits
         circuits = {}
@@ -90,7 +90,7 @@ class _QSVM_Kernel_Binary(_QSVM_Kernel_ABC):
                 if circuit is not None:
                     to_be_simulated_circuits.append(circuit)
 
-        results = self.qalgo.quantum_device.execute(to_be_simulated_circuits)
+        results = self.qalgo.quantum_exp_config.execute(to_be_simulated_circuits)
 
         # element on the diagonal is always 1: point*point=|point|^2
         if is_symmetric:
@@ -147,7 +147,7 @@ class _QSVM_Kernel_Binary(_QSVM_Kernel_ABC):
                                   D is the feature dimension.
             labels (numpy.ndarray): Nx1 array, where N is the number of data
         """
-        scaling = 1.0 if self.qalgo.quantum_device.is_statevector else None
+        scaling = 1.0 if self.qalgo.quantum_exp_config.is_statevector else None
         kernel_matrix = self.construct_kernel_matrix(data)
         labels = labels * 2 - 1  # map label from 0 --> -1 and 1 --> 1
         labels = labels.astype(np.float)

--- a/qiskit_aqua/algorithms/many_sample/qsvm/_qsvm_kernel_multiclass.py
+++ b/qiskit_aqua/algorithms/many_sample/qsvm/_qsvm_kernel_multiclass.py
@@ -16,6 +16,7 @@
 # =============================================================================
 
 import logging
+import numpy as np
 
 from qiskit_aqua.algorithms.many_sample.qsvm._qsvm_kernel_abc import _QSVM_Kernel_ABC
 from qiskit_aqua.utils import map_label_to_class_name
@@ -64,3 +65,20 @@ class _QSVM_Kernel_Multiclass(_QSVM_Kernel_ABC):
             self._ret['predicted_classes'] = predicted_classes
 
         return self._ret
+
+    def load_model(self, file_path):
+        model_npz = np.load(file_path)
+        for i in range(len(self.multiclass_classifier.estimators)):
+            self.multiclass_classifier.estimators.ret['alphas'] = model_npz['alphas_{}'.format(i)]
+            self.multiclass_classifier.estimators.ret['bias'] = model_npz['bias_{}'.format(i)]
+            self.multiclass_classifier.estimators.ret['support_vectors'] = model_npz['support_vectors_{}'.format(i)]
+            self.multiclass_classifier.estimators.ret['yin'] = model_npz['yin_{}'.format(i)]
+
+    def save_model(self, file_path):
+        model = {}
+        for i, estimator in enumerate(self.multiclass_classifier.estimators):
+            model['alphas_{}'.format(i)] = estimator.ret['alphas']
+            model['bias_{}'.format(i)] = estimator.ret['bias']
+            model['support_vectors_{}'.format(i)] = estimator.ret['support_vectors']
+            model['yin_{}'.format(i)] = estimator.ret['yin']
+        np.savez(file_path, **model)

--- a/qiskit_aqua/algorithms/many_sample/qsvm/qsvm_kernel.py
+++ b/qiskit_aqua/algorithms/many_sample/qsvm/qsvm_kernel.py
@@ -123,9 +123,9 @@ class QSVM_Kernel(QuantumAlgorithm):
             data (numpy.ndarray): NxD array, where N is the number of data,
                                   D is the feature dimension.
             labels (numpy.ndarray): Nx1 array, where N is the number of data
-            quantum_device (QuantumDevice): quantum backend with all setting
+            quantum_device (QuantumExpConfig): quantum backend with all setting
         """
-        self._quantum_device = self._quantum_device if quantum_device is None else quantum_device
+        self._quantum_exp_config = self._quantum_exp_config if quantum_device is None else quantum_device
         self.instance.train(data, labels)
 
     def test(self, data, labels, quantum_device=None):
@@ -136,11 +136,11 @@ class QSVM_Kernel(QuantumAlgorithm):
             data (numpy.ndarray): NxD array, where N is the number of data,
                                   D is the feature dimension.
             labels (numpy.ndarray): Nx1 array, where N is the number of data
-            quantum_device (QuantumDevice): quantum backend with all setting
+            quantum_device (QuantumExpConfig): quantum backend with all setting
         Returns:
             float: accuracy
         """
-        self._quantum_device = self._quantum_device if quantum_device is None else quantum_device
+        self._quantum_exp_config = self._quantum_exp_config if quantum_device is None else quantum_device
         return self.instance.test(data, labels)
 
     def predict(self, data, quantum_device=None):
@@ -150,11 +150,11 @@ class QSVM_Kernel(QuantumAlgorithm):
         Args:
             data (numpy.ndarray): NxD array, where N is the number of data,
                                   D is the feature dimension.
-            quantum_device (QuantumDevice): quantum backend with all setting
+            quantum_device (QuantumExpConfig): quantum backend with all setting
         Returns:
             numpy.ndarray: predicted labels, Nx1 array
         """
-        self._quantum_device = self._quantum_device if quantum_device is None else quantum_device
+        self._quantum_exp_config = self._quantum_exp_config if quantum_device is None else quantum_device
         return self.instance.predict(data)
 
     def _run(self):

--- a/qiskit_aqua/algorithms/many_sample/qsvm/qsvm_kernel.py
+++ b/qiskit_aqua/algorithms/many_sample/qsvm/qsvm_kernel.py
@@ -115,7 +115,7 @@ class QSVM_Kernel(QuantumAlgorithm):
         return cls(feature_map, algo_input.training_dataset, algo_input.test_dataset,
                    algo_input.datapoints, multiclass_extension)
 
-    def train(self, data, labels):
+    def train(self, data, labels, quantum_device=None):
         """
         Train the svm.
 
@@ -123,10 +123,12 @@ class QSVM_Kernel(QuantumAlgorithm):
             data (numpy.ndarray): NxD array, where N is the number of data,
                                   D is the feature dimension.
             labels (numpy.ndarray): Nx1 array, where N is the number of data
+            quantum_device (QuantumDevice): quantum backend with all setting
         """
+        self._quantum_device = self._quantum_device if quantum_device is None else quantum_device
         self.instance.train(data, labels)
 
-    def test(self, data, labels):
+    def test(self, data, labels, quantum_device=None):
         """
         Test the svm.
 
@@ -134,22 +136,25 @@ class QSVM_Kernel(QuantumAlgorithm):
             data (numpy.ndarray): NxD array, where N is the number of data,
                                   D is the feature dimension.
             labels (numpy.ndarray): Nx1 array, where N is the number of data
-
+            quantum_device (QuantumDevice): quantum backend with all setting
         Returns:
             float: accuracy
         """
+        self._quantum_device = self._quantum_device if quantum_device is None else quantum_device
         return self.instance.test(data, labels)
 
-    def predict(self, data):
+    def predict(self, data, quantum_device=None):
         """
         Predict using the svm.
 
         Args:
             data (numpy.ndarray): NxD array, where N is the number of data,
                                   D is the feature dimension.
+            quantum_device (QuantumDevice): quantum backend with all setting
         Returns:
             numpy.ndarray: predicted labels, Nx1 array
         """
+        self._quantum_device = self._quantum_device if quantum_device is None else quantum_device
         return self.instance.predict(data)
 
     def _run(self):

--- a/qiskit_aqua/algorithms/many_sample/qsvm/qsvm_kernel.py
+++ b/qiskit_aqua/algorithms/many_sample/qsvm/qsvm_kernel.py
@@ -115,7 +115,7 @@ class QSVM_Kernel(QuantumAlgorithm):
         return cls(feature_map, algo_input.training_dataset, algo_input.test_dataset,
                    algo_input.datapoints, multiclass_extension)
 
-    def train(self, data, labels, quantum_device=None):
+    def train(self, data, labels, quantum_instance=None):
         """
         Train the svm.
 
@@ -123,12 +123,12 @@ class QSVM_Kernel(QuantumAlgorithm):
             data (numpy.ndarray): NxD array, where N is the number of data,
                                   D is the feature dimension.
             labels (numpy.ndarray): Nx1 array, where N is the number of data
-            quantum_device (QuantumExpConfig): quantum backend with all setting
+            quantum_instance (QuantumInstance): quantum backend with all setting
         """
-        self._quantum_exp_config = self._quantum_exp_config if quantum_device is None else quantum_device
+        self._quantum_instance = self._quantum_instance if quantum_instance is None else quantum_instance
         self.instance.train(data, labels)
 
-    def test(self, data, labels, quantum_device=None):
+    def test(self, data, labels, quantum_instance=None):
         """
         Test the svm.
 
@@ -136,25 +136,25 @@ class QSVM_Kernel(QuantumAlgorithm):
             data (numpy.ndarray): NxD array, where N is the number of data,
                                   D is the feature dimension.
             labels (numpy.ndarray): Nx1 array, where N is the number of data
-            quantum_device (QuantumExpConfig): quantum backend with all setting
+            quantum_instance (QuantumInstance): quantum backend with all setting
         Returns:
             float: accuracy
         """
-        self._quantum_exp_config = self._quantum_exp_config if quantum_device is None else quantum_device
+        self._quantum_instance = self._quantum_instance if quantum_instance is None else quantum_instance
         return self.instance.test(data, labels)
 
-    def predict(self, data, quantum_device=None):
+    def predict(self, data, quantum_instance=None):
         """
         Predict using the svm.
 
         Args:
             data (numpy.ndarray): NxD array, where N is the number of data,
                                   D is the feature dimension.
-            quantum_device (QuantumExpConfig): quantum backend with all setting
+            quantum_instance (QuantumInstance): quantum backend with all setting
         Returns:
             numpy.ndarray: predicted labels, Nx1 array
         """
-        self._quantum_exp_config = self._quantum_exp_config if quantum_device is None else quantum_device
+        self._quantum_instance = self._quantum_instance if quantum_instance is None else quantum_instance
         return self.instance.predict(data)
 
     def _run(self):

--- a/qiskit_aqua/algorithms/many_sample/qsvm/qsvm_kernel.py
+++ b/qiskit_aqua/algorithms/many_sample/qsvm/qsvm_kernel.py
@@ -86,7 +86,8 @@ class QSVM_Kernel(QuantumAlgorithm):
         if multiclass_extension is None:
             qsvm_instance = _QSVM_Kernel_Binary(feature_map, self, training_dataset, test_dataset, datapoints)
         else:
-            qsvm_instance = _QSVM_Kernel_Multiclass(feature_map, self, training_dataset, test_dataset, datapoints, multiclass_extension)
+            qsvm_instance = _QSVM_Kernel_Multiclass(
+                feature_map, self, training_dataset, test_dataset, datapoints, multiclass_extension)
 
         self.instance = qsvm_instance
 
@@ -151,7 +152,7 @@ class QSVM_Kernel(QuantumAlgorithm):
         """
         return self.instance.predict(data)
 
-    def run(self):
+    def _run(self):
         return self.instance.run()
 
     @property
@@ -167,5 +168,11 @@ class QSVM_Kernel(QuantumAlgorithm):
         return self.instance.ret
 
     @ret.setter
-    def ret(self, new_ret):
-        self.instance.ret = new_ret
+    def ret(self, new_value):
+        self.instance.ret = new_value
+
+    def load_model(self, file_path):
+        self.instance.load_model(file_path)
+
+    def save_model(self, file_path):
+        self.instance.save_model(file_path)

--- a/qiskit_aqua/algorithms/quantumalgorithm.py
+++ b/qiskit_aqua/algorithms/quantumalgorithm.py
@@ -29,7 +29,7 @@ import logging
 import numpy as np
 from qiskit.backends import BaseBackend
 
-from qiskit_aqua import Pluggable, QuantumDevice, AquaError
+from qiskit_aqua import Pluggable, QuantumExpConfig, AquaError
 
 logger = logging.getLogger(__name__)
 
@@ -60,7 +60,7 @@ class QuantumAlgorithm(Pluggable):
         super().__init__()
         self._random_seed = None
         self._random = None
-        self._quantum_device = None
+        self._quantum_exp_config = None
 
     @property
     def random_seed(self):
@@ -86,7 +86,7 @@ class QuantumAlgorithm(Pluggable):
         """Execute the algorithm with selected backend.
 
         Args:
-            quantum_device (QuantumDevice or BaseBackend): the experiemental setting.
+            quantum_device (QuantumExpConfig or BaseBackend): the experiemental setting.
 
         Returns:
             dict: results of an algorithm.
@@ -95,8 +95,8 @@ class QuantumAlgorithm(Pluggable):
             if quantum_device is None:
                 AquaError("Quantum device or backend is needed since you are running quanutm algorithm.")
             if isinstance(quantum_device, BaseBackend):
-                quantum_device = QuantumDevice(quantum_device, **kwargs)
-            self._quantum_device = quantum_device
+                quantum_device = QuantumExpConfig(quantum_device, **kwargs)
+            self._quantum_exp_config = quantum_device
         return self._run()
 
     @abstractmethod
@@ -104,5 +104,5 @@ class QuantumAlgorithm(Pluggable):
         raise NotImplementedError()
 
     @property
-    def quantum_device(self):
-        return self._quantum_device
+    def quantum_exp_config(self):
+        return self._quantum_exp_config

--- a/qiskit_aqua/algorithms/quantumalgorithm.py
+++ b/qiskit_aqua/algorithms/quantumalgorithm.py
@@ -23,18 +23,12 @@ class in this module.
 Doing so requires that the required algorithm interface is implemented.
 """
 
-from qiskit_aqua import Pluggable
 from abc import abstractmethod
 import logging
+
 import numpy as np
-import qiskit
-from qiskit import __version__ as qiskit_version
-from qiskit.backends import BaseBackend
-from qiskit.backends.ibmq.credentials import Credentials
-from qiskit.backends.ibmq.ibmqsingleprovider import IBMQSingleProvider
-from qiskit_aqua import AquaError
-from qiskit_aqua.utils import run_circuits
-from qiskit_aqua_cmd import Preferences
+
+from qiskit_aqua import Pluggable, QuantumDevice
 
 logger = logging.getLogger(__name__)
 
@@ -51,15 +45,6 @@ class QuantumAlgorithm(Pluggable):
     SECTION_KEY_FEATURE_MAP = 'feature_map'
     SECTION_KEY_MULTICLASS_EXTENSION = 'multiclass_extension'
 
-    UNSUPPORTED_BACKENDS = [
-        'unitary_simulator', 'clifford_simulator']
-
-    EQUIVALENT_BACKENDS = {'statevector_simulator_py': 'statevector_simulator',
-                           'statevector_simulator_sympy': 'statevector_simulator',
-                           'statevector_simulator_projectq': 'statevector_simulator',
-                           'qasm_simulator_py': 'qasm_simulator',
-                           'qasm_simulator_projectq': 'qasm_simulator'
-                           }
     """
     Base class for Algorithms.
 
@@ -72,13 +57,8 @@ class QuantumAlgorithm(Pluggable):
     @abstractmethod
     def __init__(self):
         super().__init__()
-        self._backend = None
-        self._execute_config = {}
-        self._qjob_config = {}
         self._random_seed = None
         self._random = None
-        self._show_circuit_summary = False
-        self._has_shared_circuits = False
 
     @property
     def random_seed(self):
@@ -100,199 +80,10 @@ class QuantumAlgorithm(Pluggable):
                 self._random = np.random.RandomState(self._random_seed)
         return self._random
 
-    @property
-    def backend(self):
-        """Return BaseBackend backend object"""
-        return self._backend
-
-    @staticmethod
-    def is_statevector_backend(backend):
-        """
-        Returns True if backend object is statevector.
-
-        Args:
-            backend (BaseBackend): backend instance
-        Returns:
-            Result (Boolean): True is statevector
-        """
-        return backend.configuration().backend_name.startswith('statevector') if backend is not None else False
-
-    @staticmethod
-    def backend_name(backend):
-        """
-        Returns backend name.
-
-        Args:
-            backend (BaseBackend):  backend instance
-        Returns:
-            Name (str): backend name
-        """
-        return backend.configuration().backend_name if backend is not None else ''
-
-    def enable_circuit_summary(self):
-        """Enable showing the summary of circuits."""
-        self._show_circuit_summary = True
-
-    def disable_circuit_summary(self):
-        """Disable showing the summary of circuits."""
-        self._show_circuit_summary = False
-
-    def setup_quantum_backend(self, backend='statevector_simulator', shots=1024, pass_manager=None,
-                              noise_params=None, coupling_map=None, initial_layout=None, hpc_params=None,
-                              basis_gates=None, max_credits=10, timeout=None, wait=5):
-        """
-        Setup the quantum backend.
-
-        Args:
-            backend (str or BaseBackend): name of or instance of selected backend
-            shots (int): number of shots for the backend
-            pass_manager (PassManager): pass manager to handle how to compile the circuits
-            noise_params (dict): the noise setting for simulator
-            coupling_map (list): coupling map (perhaps custom) to target in mapping
-            initial_layout (dict): initial layout of qubits in mapping
-            hpc_params (dict): HPC simulator parameters
-            basis_gates (str): comma-separated basis gate set to compile to
-            max_credits (int): maximum credits to use
-            timeout (float or None): seconds to wait for job. If None, wait indefinitely
-            wait (float): seconds between queries
-
-        Raises:
-            AquaError: set backend with invalid Qconfig
-        """
-        if backend is None:
-            raise AquaError('Missing algorithm backend')
-
-        if isinstance(backend, str):
-            operational_backends = self.register_and_get_operational_backends()
-            if QuantumAlgorithm.EQUIVALENT_BACKENDS.get(backend, backend) not in operational_backends:
-                raise AquaError("This backend '{}' is not operational for the quantum algorithm, \
-                                     select any one below: {}".format(backend, operational_backends))
-
-        self._qjob_config = {'timeout': timeout,
-                             'wait': wait}
-
-        my_backend = None
-        if isinstance(backend, BaseBackend):
-            my_backend = backend
-        else:
-            try:
-                my_backend = qiskit.Aer.get_backend(backend)
-            except KeyError:
-                preferences = Preferences()
-                my_backend = qiskit.IBMQ.get_backend(backend,
-                                                     url=preferences.get_url(
-                                                         ''),
-                                                     token=preferences.get_token(''))
-
-            if my_backend is None:
-                raise AquaError(
-                    "Missing algorithm backend '{}'".format(backend))
-
-        self._backend = my_backend
-
-        shots = 1 if QuantumAlgorithm.is_statevector_backend(
-            my_backend) else shots
-        noise_params = noise_params if my_backend.configuration().simulator else None
-
-        if my_backend.configuration().local:
-            self._qjob_config.pop('wait', None)
-        if coupling_map is None:
-            coupling_map = my_backend.configuration().to_dict().get('coupling_map', None)
-        if basis_gates is None:
-            basis_gates = my_backend.configuration().basis_gates
-
-        if isinstance(basis_gates, list):
-            basis_gates = str(basis_gates)
-
-        self._execute_config = {'shots': shots,
-                                'pass_manager': pass_manager,
-                                'config': {"noise_params": noise_params},
-                                'basis_gates': basis_gates,
-                                'coupling_map': coupling_map,
-                                'initial_layout': initial_layout,
-                                'max_credits': max_credits,
-                                'seed': self._random_seed,
-                                'qobj_id': None,
-                                'hpc': hpc_params,
-                                'seed_mapper': self._random_seed}
-
-        info = "Algorithm: '{}' setup with backend '{}', with following setting:\n {}\n{}".format(
-            self._configuration['name'], my_backend.configuration().backend_name, self._execute_config, self._qjob_config)
-
-        logger.info('Qiskit Terra version {}'.format(qiskit_version))
-        logger.info(info)
-
-    @property
-    def has_shared_circuits(self):
-        return self._has_shared_circuits
-
-    @has_shared_circuits.setter
-    def has_shared_circuits(self, new_value):
-        self._has_shared_circuits = new_value
-
-    def execute(self, circuits):
-        """
-        A wrapper for all algorithms to interface with quantum backend.
-
-        Args:
-            circuits (QuantumCircuit or list[QuantumCircuit]): circuits to execute
-
-        Returns:
-            Result: Result object
-        """
-        result = run_circuits.run_circuits(circuits,
-                                           self._backend,
-                                           self._execute_config,
-                                           self._qjob_config,
-                                           self._show_circuit_summary,
-                                           self.has_shared_circuits)
-        if self._show_circuit_summary:
-            self.disable_circuit_summary()
-
-        return result
-
-    @staticmethod
-    def register_and_get_operational_backends():
-        # update registration info using internal methods because:
-        # at this point I don't want to save to or removecredentials from disk
-        # I want to update url, proxies etc without removing token and
-        # re-adding in 2 methods
-
-        ibmq_backends = []
-        try:
-            credentials = None
-            preferences = Preferences()
-            url = preferences.get_url()
-            token = preferences.get_token()
-            if url is not None and url != '' and token is not None and token != '':
-                credentials = Credentials(token,
-                                          url,
-                                          proxies=preferences.get_proxies({}))
-            if credentials is not None:
-                qiskit.IBMQ._accounts[credentials.unique_id()] = IBMQSingleProvider(
-                    credentials, qiskit.IBMQ)
-                logger.debug("Registered with Qiskit successfully.")
-                ibmq_backends = [x.name()
-                                 for x in qiskit.IBMQ.backends(url=url, token=token)]
-        except Exception as e:
-            logger.debug(
-                "Failed to register with Qiskit: {}".format(str(e)))
-
-        backends = set()
-        aer_backends = [x.name() for x in qiskit.Aer.backends()]
-        for aer_backend in aer_backends:
-            backend = aer_backend
-            supported = True
-            for unsupported_backend in QuantumAlgorithm.UNSUPPORTED_BACKENDS:
-                if backend.startswith(unsupported_backend):
-                    supported = False
-                    break
-
-            if supported:
-                backends.add(backend)
-
-        return list(backends) + ibmq_backends
+    def run(self, quantum_device):
+        self._quantum_device = quantum_device
+        return self._run()
 
     @abstractmethod
-    def run(self):
-        pass
+    def _run(self):
+        raise NotImplementedError()

--- a/qiskit_aqua/algorithms/quantumalgorithm.py
+++ b/qiskit_aqua/algorithms/quantumalgorithm.py
@@ -29,7 +29,7 @@ import logging
 import numpy as np
 from qiskit.backends import BaseBackend
 
-from qiskit_aqua import Pluggable, QuantumExpConfig, AquaError
+from qiskit_aqua import Pluggable, QuantumInstance, AquaError
 
 logger = logging.getLogger(__name__)
 
@@ -60,7 +60,7 @@ class QuantumAlgorithm(Pluggable):
         super().__init__()
         self._random_seed = None
         self._random = None
-        self._quantum_exp_config = None
+        self._quantum_instance = None
 
     @property
     def random_seed(self):
@@ -82,21 +82,21 @@ class QuantumAlgorithm(Pluggable):
                 self._random = np.random.RandomState(self._random_seed)
         return self._random
 
-    def run(self, quantum_device=None, **kwargs):
+    def run(self, quantum_instance=None, **kwargs):
         """Execute the algorithm with selected backend.
 
         Args:
-            quantum_device (QuantumExpConfig or BaseBackend): the experiemental setting.
+            quantum_instance (QuantumInstance or BaseBackend): the experiemental setting.
 
         Returns:
             dict: results of an algorithm.
         """
         if not self.configuration.get('classical', False):
-            if quantum_device is None:
+            if quantum_instance is None:
                 AquaError("Quantum device or backend is needed since you are running quanutm algorithm.")
-            if isinstance(quantum_device, BaseBackend):
-                quantum_device = QuantumExpConfig(quantum_device, **kwargs)
-            self._quantum_exp_config = quantum_device
+            if isinstance(quantum_instance, BaseBackend):
+                quantum_instance = QuantumInstance(quantum_instance, **kwargs)
+            self._quantum_instance = quantum_instance
         return self._run()
 
     @abstractmethod
@@ -104,5 +104,5 @@ class QuantumAlgorithm(Pluggable):
         raise NotImplementedError()
 
     @property
-    def quantum_exp_config(self):
-        return self._quantum_exp_config
+    def quantum_instance(self):
+        return self._quantum_instance

--- a/qiskit_aqua/algorithms/single_sample/grover/grover.py
+++ b/qiskit_aqua/algorithms/single_sample/grover/grover.py
@@ -167,6 +167,8 @@ class Grover(QuantumAlgorithm):
         return assignment, oracle_evaluation
 
     def construct_circuit(self):
+        if self._qc_prefix is None or self._qc_amplitude_amplification_single_iteration is None or self._qc_measurement is None:
+            self._construct_circuit_components()
         if self._qc_amplitude_amplification is None:
             self._qc_amplitude_amplification = QuantumCircuit() + self._qc_amplitude_amplification_single_iteration
         qc = self._qc_prefix + self._qc_amplitude_amplification + self._qc_measurement

--- a/qiskit_aqua/algorithms/single_sample/grover/grover.py
+++ b/qiskit_aqua/algorithms/single_sample/grover/grover.py
@@ -161,7 +161,7 @@ class Grover(QuantumAlgorithm):
     def _run_with_num_iterations(self):
         qc = self.construct_circuit()
         self._ret['circuit'] = qc
-        self._ret['measurements'] = self._quantum_exp_config.execute(qc).get_counts(qc)
+        self._ret['measurements'] = self._quantum_instance.execute(qc).get_counts(qc)
         assignment = self._oracle.interpret_measurement(self._ret['measurements'])
         oracle_evaluation = self._oracle.evaluate_classically(assignment)
         return assignment, oracle_evaluation
@@ -176,9 +176,9 @@ class Grover(QuantumAlgorithm):
 
     def _run(self):
 
-        if self._quantum_exp_config.is_statevector:
+        if self._quantum_instance.is_statevector:
             raise ValueError('Selected backend  "{}" does not support measurements.'.format(
-                self._quantum_exp_config.backend_name))
+                self._quantum_instance.backend_name))
 
         if self._qc_prefix is None or self._qc_amplitude_amplification_single_iteration is None or self._qc_measurement is None:
             self._construct_circuit_components()

--- a/qiskit_aqua/algorithms/single_sample/grover/grover.py
+++ b/qiskit_aqua/algorithms/single_sample/grover/grover.py
@@ -161,7 +161,7 @@ class Grover(QuantumAlgorithm):
     def _run_with_num_iterations(self):
         qc = self.construct_circuit()
         self._ret['circuit'] = qc
-        self._ret['measurements'] = self._quantum_device.execute(qc).get_counts(qc)
+        self._ret['measurements'] = self._quantum_exp_config.execute(qc).get_counts(qc)
         assignment = self._oracle.interpret_measurement(self._ret['measurements'])
         oracle_evaluation = self._oracle.evaluate_classically(assignment)
         return assignment, oracle_evaluation
@@ -174,9 +174,9 @@ class Grover(QuantumAlgorithm):
 
     def _run(self):
 
-        if self._quantum_device.is_statevector:
+        if self._quantum_exp_config.is_statevector:
             raise ValueError('Selected backend  "{}" does not support measurements.'.format(
-                self._quantum_device.backend_name))
+                self._quantum_exp_config.backend_name))
 
         if self._qc_prefix is None or self._qc_amplitude_amplification_single_iteration is None or self._qc_measurement is None:
             self._construct_circuit_components()

--- a/qiskit_aqua/algorithms/single_sample/grover/grover.py
+++ b/qiskit_aqua/algorithms/single_sample/grover/grover.py
@@ -19,7 +19,10 @@ The Grover Quantum algorithm.
 """
 
 import logging
+
 from qiskit import ClassicalRegister, QuantumCircuit
+from qiskit.qasm import pi
+
 from qiskit_aqua import QuantumAlgorithm, AquaError
 from qiskit_aqua import PluggableType, get_pluggable_class
 
@@ -67,13 +70,17 @@ class Grover(QuantumAlgorithm):
         self._oracle = oracle
         self._max_num_iterations = 2 ** (len(self._oracle.variable_register()) / 2)
         self._incremental = incremental
-        self._num_iterations = num_iterations
+        self._num_iterations = num_iterations if not incremental else 1
         if incremental:
             logger.debug('Incremental mode specified, ignoring "num_iterations".')
         else:
             if num_iterations > self._max_num_iterations:
                 logger.warning('The specified value {} for "num_iterations" might be too high.'.format(num_iterations))
         self._ret = {}
+        self._qc_prefix = None
+        self._qc_amplitude_amplification_single_iteration = None
+        self._qc_amplitude_amplification = None
+        self._qc_measurement = None
 
     @classmethod
     def init_params(cls, params, algo_input):
@@ -103,7 +110,7 @@ class Grover(QuantumAlgorithm):
                 self._oracle.ancillary_register(),
                 measurement_cr
             )
-            qc_amplitude_amplification = QuantumCircuit(
+            qc_amplitude_amplification_single_iteration = QuantumCircuit(
                 self._oracle.variable_register(),
                 self._oracle.ancillary_register()
             )
@@ -112,33 +119,33 @@ class Grover(QuantumAlgorithm):
                 self._oracle.variable_register(),
                 measurement_cr
             )
-            qc_amplitude_amplification = QuantumCircuit(
+            qc_amplitude_amplification_single_iteration = QuantumCircuit(
                 self._oracle.variable_register()
             )
-        qc_prefix.h(self._oracle.variable_register())
+        qc_prefix.u2(0, pi, self._oracle.variable_register())  # h
 
-        qc_amplitude_amplification += self._oracle.construct_circuit()
-        qc_amplitude_amplification.h(self._oracle.variable_register())
-        qc_amplitude_amplification.x(self._oracle.variable_register())
-        qc_amplitude_amplification.x(self._oracle.outcome_register())
-        qc_amplitude_amplification.h(self._oracle.outcome_register())
+        qc_amplitude_amplification_single_iteration += self._oracle.construct_circuit()
+        qc_amplitude_amplification_single_iteration.u2(0, pi, self._oracle.variable_register())  # h
+        qc_amplitude_amplification_single_iteration.u3(pi, 0, pi, self._oracle.variable_register())  # x
+        qc_amplitude_amplification_single_iteration.u3(pi, 0, pi, self._oracle.outcome_register())  # x
+        qc_amplitude_amplification_single_iteration.u2(0, pi, self._oracle.outcome_register())  # h
         if self._oracle.ancillary_register():
-            qc_amplitude_amplification.cnx(
+            qc_amplitude_amplification_single_iteration.cnx(
                 [self._oracle.variable_register()[i] for i in range(len(self._oracle.variable_register()))],
                 [self._oracle.ancillary_register()[i] for i in range(len(self._oracle.ancillary_register()))],
                 self._oracle.outcome_register()[0]
             )
         else:
-            qc_amplitude_amplification.cnx(
+            qc_amplitude_amplification_single_iteration.cnx(
                 [self._oracle.variable_register()[i] for i in range(len(self._oracle.variable_register()))],
                 [],
                 self._oracle.outcome_register()[0]
             )
-        qc_amplitude_amplification.h(self._oracle.outcome_register())
-        qc_amplitude_amplification.x(self._oracle.variable_register())
-        qc_amplitude_amplification.x(self._oracle.outcome_register())
-        qc_amplitude_amplification.h(self._oracle.variable_register())
-        qc_amplitude_amplification.h(self._oracle.outcome_register())
+        qc_amplitude_amplification_single_iteration.u2(0, pi, self._oracle.outcome_register())  # h
+        qc_amplitude_amplification_single_iteration.u3(pi, 0, pi, self._oracle.variable_register())  # x
+        qc_amplitude_amplification_single_iteration.u3(pi, 0, pi, self._oracle.outcome_register())  # x
+        qc_amplitude_amplification_single_iteration.u2(0, pi, self._oracle.variable_register())  # h
+        qc_amplitude_amplification_single_iteration.u2(0, pi, self._oracle.outcome_register())  # h
 
         qc_measurement = QuantumCircuit(
             self._oracle.variable_register(),
@@ -147,42 +154,48 @@ class Grover(QuantumAlgorithm):
         qc_measurement.barrier(self._oracle.variable_register())
         qc_measurement.measure(self._oracle.variable_register(), measurement_cr)
 
-        return qc_prefix, qc_amplitude_amplification, qc_measurement
+        self._qc_prefix = qc_prefix
+        self._qc_measurement = qc_measurement
+        self._qc_amplitude_amplification_single_iteration = qc_amplitude_amplification_single_iteration
 
-    def _run_with_num_iterations(self, qc_prefix, qc_amplitude_amplification, qc_measurement):
-        qc = qc_prefix + qc_amplitude_amplification + qc_measurement
+    def _run_with_num_iterations(self):
+        qc = self.construct_circuit()
         self._ret['circuit'] = qc
-        self._ret['measurements'] = self.execute(qc).get_counts(qc)
+        self._ret['measurements'] = self._quantum_device.execute(qc).get_counts(qc)
         assignment = self._oracle.interpret_measurement(self._ret['measurements'])
         oracle_evaluation = self._oracle.evaluate_classically(assignment)
         return assignment, oracle_evaluation
 
-    def run(self):
+    def construct_circuit(self):
+        if self._qc_amplitude_amplification is None:
+            self._qc_amplitude_amplification = QuantumCircuit() + self._qc_amplitude_amplification_single_iteration
+        qc = self._qc_prefix + self._qc_amplitude_amplification + self._qc_measurement
+        return qc
 
-        if QuantumAlgorithm.is_statevector_backend(self.backend):
+    def _run(self):
+
+        if self._quantum_device.is_statevector:
             raise ValueError('Selected backend  "{}" does not support measurements.'.format(
-                QuantumAlgorithm.backend_name(self.backend)))
+                self._quantum_device.backend_name))
 
-        qc_prefix, qc_amplitude_amplification_single_iteration, qc_measurement = self._construct_circuit_components()
-        qc_amplitude_amplification = QuantumCircuit()
+        if self._qc_prefix is None or self._qc_amplitude_amplification_single_iteration is None or self._qc_measurement is None:
+            self._construct_circuit_components()
+
+        self._qc_amplitude_amplification = QuantumCircuit()
 
         if self._incremental:
-            qc_amplitude_amplification += qc_amplitude_amplification_single_iteration
+            self._qc_amplitude_amplification += self._qc_amplitude_amplification_single_iteration
             current_num_iterations = 1
             while current_num_iterations <= self._max_num_iterations:
-                assignment, oracle_evaluation = self._run_with_num_iterations(
-                    qc_prefix, qc_amplitude_amplification, qc_measurement
-                )
+                assignment, oracle_evaluation = self._run_with_num_iterations()
                 if oracle_evaluation:
                     break
                 current_num_iterations += 1
-                qc_amplitude_amplification += qc_amplitude_amplification_single_iteration
+                self._qc_amplitude_amplification += self._qc_amplitude_amplification_single_iteration
         else:
             for i in range(self._num_iterations):
-                qc_amplitude_amplification += qc_amplitude_amplification_single_iteration
-            assignment, oracle_evaluation = self._run_with_num_iterations(
-                qc_prefix, qc_amplitude_amplification, qc_measurement
-            )
+                self._qc_amplitude_amplification += self._qc_amplitude_amplification_single_iteration
+            assignment, oracle_evaluation = self._run_with_num_iterations()
 
         self._ret['result'] = assignment
         self._ret['oracle_evaluation'] = oracle_evaluation

--- a/qiskit_aqua/algorithms/single_sample/iqpe/iqpe.py
+++ b/qiskit_aqua/algorithms/single_sample/iqpe/iqpe.py
@@ -174,7 +174,7 @@ class IQPE(QuantumAlgorithm):
 
     def _estimate_phase_iteratively(self):
         """Iteratively construct the different order of controlled evolution circuit to carry out phase estimation"""
-        if self._quantum_exp_config.is_statevector:
+        if self._quantum_instance.is_statevector:
             raise ValueError('Selected backend does not support measurements.')
 
         pauli_list = self._operator.reorder_paulis(grouping=self._paulis_grouping)
@@ -193,7 +193,7 @@ class IQPE(QuantumAlgorithm):
         for k in range(self._num_iterations, 0, -1):
             omega_coef /= 2
             qc = self._construct_kth_evolution(slice_pauli_list, k, -2 * np.pi * omega_coef)
-            measurements = self._quantum_exp_config.execute(qc).get_counts(qc)
+            measurements = self._quantum_instance.execute(qc).get_counts(qc)
 
             if '0' not in measurements:
                 if '1' in measurements:

--- a/qiskit_aqua/algorithms/single_sample/iqpe/iqpe.py
+++ b/qiskit_aqua/algorithms/single_sample/iqpe/iqpe.py
@@ -174,7 +174,7 @@ class IQPE(QuantumAlgorithm):
 
     def _estimate_phase_iteratively(self):
         """Iteratively construct the different order of controlled evolution circuit to carry out phase estimation"""
-        if self._quantum_device.is_statevector:
+        if self._quantum_exp_config.is_statevector:
             raise ValueError('Selected backend does not support measurements.')
 
         pauli_list = self._operator.reorder_paulis(grouping=self._paulis_grouping)
@@ -193,7 +193,7 @@ class IQPE(QuantumAlgorithm):
         for k in range(self._num_iterations, 0, -1):
             omega_coef /= 2
             qc = self._construct_kth_evolution(slice_pauli_list, k, -2 * np.pi * omega_coef)
-            measurements = self._quantum_device.execute(qc).get_counts(qc)
+            measurements = self._quantum_exp_config.execute(qc).get_counts(qc)
 
             if '0' not in measurements:
                 if '1' in measurements:

--- a/qiskit_aqua/algorithms/single_sample/iqpe/iqpe.py
+++ b/qiskit_aqua/algorithms/single_sample/iqpe/iqpe.py
@@ -174,7 +174,7 @@ class IQPE(QuantumAlgorithm):
 
     def _estimate_phase_iteratively(self):
         """Iteratively construct the different order of controlled evolution circuit to carry out phase estimation"""
-        if QuantumAlgorithm.is_statevector_backend(self.backend):
+        if self._quantum_device.is_statevector:
             raise ValueError('Selected backend does not support measurements.')
 
         pauli_list = self._operator.reorder_paulis(grouping=self._paulis_grouping)
@@ -193,7 +193,7 @@ class IQPE(QuantumAlgorithm):
         for k in range(self._num_iterations, 0, -1):
             omega_coef /= 2
             qc = self._construct_kth_evolution(slice_pauli_list, k, -2 * np.pi * omega_coef)
-            measurements = self.execute(qc).get_counts(qc)
+            measurements = self._quantum_device.execute(qc).get_counts(qc)
 
             if '0' not in measurements:
                 if '1' in measurements:
@@ -249,6 +249,6 @@ class IQPE(QuantumAlgorithm):
         )])
         self._ret['energy'] = self._ret['phase'] / self._ret['stretch'] - self._ret['translation']
 
-    def run(self):
+    def _run(self):
         self._compute_energy()
         return self._ret

--- a/qiskit_aqua/algorithms/single_sample/qpe/qpe.py
+++ b/qiskit_aqua/algorithms/single_sample/qpe/qpe.py
@@ -172,11 +172,11 @@ class QPE(QuantumAlgorithm):
                    expansion_order=expansion_order)
 
     def _compute_energy(self):
-        if self._quantum_exp_config.is_statevector:
+        if self._quantum_instance.is_statevector:
             raise ValueError('Selected backend does not support measurements.')
 
         qc = self._phase_estimation_component.construct_circuit(measure=True)
-        result = self._quantum_exp_config.execute(qc)
+        result = self._quantum_instance.execute(qc)
         rd = result.get_counts(qc)
         rets = sorted([(rd[k], k) for k in rd])[::-1]
         ret = rets[0][-1][::-1]

--- a/qiskit_aqua/algorithms/single_sample/qpe/qpe.py
+++ b/qiskit_aqua/algorithms/single_sample/qpe/qpe.py
@@ -172,11 +172,11 @@ class QPE(QuantumAlgorithm):
                    expansion_order=expansion_order)
 
     def _compute_energy(self):
-        if self._quantum_device.is_statevector:
+        if self._quantum_exp_config.is_statevector:
             raise ValueError('Selected backend does not support measurements.')
 
         qc = self._phase_estimation_component.construct_circuit(measure=True)
-        result = self._quantum_device.execute(qc)
+        result = self._quantum_exp_config.execute(qc)
         rd = result.get_counts(qc)
         rets = sorted([(rd[k], k) for k in rd])[::-1]
         ret = rets[0][-1][::-1]

--- a/qiskit_aqua/algorithms/single_sample/qpe/qpe.py
+++ b/qiskit_aqua/algorithms/single_sample/qpe/qpe.py
@@ -172,11 +172,11 @@ class QPE(QuantumAlgorithm):
                    expansion_order=expansion_order)
 
     def _compute_energy(self):
-        if QuantumAlgorithm.is_statevector_backend(self.backend):
+        if self._quantum_device.is_statevector:
             raise ValueError('Selected backend does not support measurements.')
 
         qc = self._phase_estimation_component.construct_circuit(measure=True)
-        result = self.execute(qc)
+        result = self._quantum_device.execute(qc)
         rd = result.get_counts(qc)
         rets = sorted([(rd[k], k) for k in rd])[::-1]
         ret = rets[0][-1][::-1]
@@ -187,6 +187,6 @@ class QPE(QuantumAlgorithm):
         self._ret['top_measurement_decimal'] = retval
         self._ret['energy'] = retval / self._ret['stretch'] - self._ret['translation']
 
-    def run(self):
+    def _run(self):
         self._compute_energy()
         return self._ret

--- a/qiskit_aqua/operator.py
+++ b/qiskit_aqua/operator.py
@@ -32,7 +32,7 @@ from qiskit.quantum_info import Pauli
 from qiskit.qasm import pi
 
 from qiskit_aqua import AquaError, QuantumDevice
-from qiskit_aqua.utils import PauliGraph, run_circuits, find_regs_by_name
+from qiskit_aqua.utils import PauliGraph, compile_and_run_circuits, find_regs_by_name
 
 logger = logging.getLogger(__name__)
 
@@ -729,7 +729,7 @@ class Operator(object):
             avg = np.vdot(quantum_state, self._matrix.dot(quantum_state))
         return avg
 
-    def eval(self, operator_mode, input_circuit, backend, execute_config=None, qjob_config=None):
+    def eval(self, operator_mode, input_circuit, backend, backend_config=None, compile_config=None, run_config=None, qjob_config=None):
         """
         Supporting three ways to evaluate the given circuits with the operator.
         1. If `input_circuit` is a numpy.ndarray, it will directly perform inner product with the operator.
@@ -742,13 +742,17 @@ class Operator(object):
             operator_mode (str): representation of operator, including paulis, grouped_paulis and matrix
             input_circuit (QuantumCircuit or numpy.ndarray): the quantum circuit.
             backend (BaseBackend): backend selection for quantum machine.
-            execute_config (dict): execution setting to quautum backend, refer to qiskit.execute for details.
+            backend_config (dict): configuration for backend
+            compile_config (dict): configuration for compilation
+            run_config (dict): configuration for running a circuit
             qjob_config (dict): the setting to retrieve results from quantum backend, including timeout and wait.
 
         Returns:
             float, float: mean and standard deviation of avg
         """
-        execute_config = execute_config or {}
+        backend_config = backend_config or {}
+        compile_config = compile_config or {}
+        run_config = run_config or {}
         qjob_config = qjob_config or {}
 
         if isinstance(input_circuit, np.ndarray):
@@ -756,22 +760,23 @@ class Operator(object):
             std_dev = 0.0
         else:
             if QuantumDevice.is_statevector_backend(backend):
-                execute_config['shots'] = 1
+                run_config['shots'] = 1
                 has_shared_circuits = True
 
                 if operator_mode == 'matrix':
                     has_shared_circuits = False
 
-                if 'config' in execute_config:
-                    if 'noise_params' in execute_config['config']:
+                if 'config' in backend_config:
+                    if 'noise_params' in backend_config['config']:
                         has_shared_circuits = False
             else:
                 has_shared_circuits = False
 
             circuits = self.construct_evaluation_circuit(operator_mode, input_circuit, backend)
-            result = run_circuits(circuits, backend=backend, execute_config=execute_config,
-                                  qjob_config=qjob_config, show_circuit_summary=self._summarize_circuits,
-                                  has_shared_circuits=has_shared_circuits)
+            result = compile_and_run_circuits(circuits, backend=backend, backend_config=backend_config,
+                                              compile_config=compile_config, run_config=run_config,
+                                              qjob_config=qjob_config, show_circuit_summary=self._summarize_circuits,
+                                              has_shared_circuits=has_shared_circuits)
             avg, std_dev = self.evaluate_with_result(operator_mode, circuits, backend, result)
 
         return avg, std_dev

--- a/qiskit_aqua/operator.py
+++ b/qiskit_aqua/operator.py
@@ -31,7 +31,7 @@ from qiskit import ClassicalRegister, QuantumCircuit
 from qiskit.quantum_info import Pauli
 from qiskit.qasm import pi
 
-from qiskit_aqua import AquaError, QuantumAlgorithm
+from qiskit_aqua import AquaError, QuantumDevice
 from qiskit_aqua.utils import PauliGraph, run_circuits, find_regs_by_name
 
 logger = logging.getLogger(__name__)
@@ -548,7 +548,7 @@ class Operator(object):
         Returns:
             [QuantumCircuit]: the circuits for evaluation.
         """
-        if QuantumAlgorithm.is_statevector_backend(backend):
+        if QuantumDevice.is_statevector_backend(backend):
             if operator_mode == 'matrix':
                 circuits = [input_circuit]
             else:
@@ -636,7 +636,7 @@ class Operator(object):
             float: the standard deviation
         """
         avg, std_dev, variance = 0.0, 0.0, 0.0
-        if QuantumAlgorithm.is_statevector_backend(backend):
+        if QuantumDevice.is_statevector_backend(backend):
             if operator_mode == "matrix":
                 self._check_representation("matrix")
                 if self._dia_matrix is None:
@@ -755,7 +755,7 @@ class Operator(object):
             avg = self._eval_directly(input_circuit)
             std_dev = 0.0
         else:
-            if QuantumAlgorithm.is_statevector_backend(backend):
+            if QuantumDevice.is_statevector_backend(backend):
                 execute_config['shots'] = 1
                 has_shared_circuits = True
 

--- a/qiskit_aqua/operator.py
+++ b/qiskit_aqua/operator.py
@@ -31,7 +31,7 @@ from qiskit import ClassicalRegister, QuantumCircuit
 from qiskit.quantum_info import Pauli
 from qiskit.qasm import pi
 
-from qiskit_aqua import AquaError, QuantumDevice
+from qiskit_aqua import AquaError, QuantumExpConfig
 from qiskit_aqua.utils import PauliGraph, compile_and_run_circuits, find_regs_by_name
 
 logger = logging.getLogger(__name__)
@@ -67,7 +67,6 @@ class Operator(object):
 
         # use for fast lookup whether or not the paulis is existed.
         self._simplify_paulis()
-
         self._summarize_circuits = False
 
     def _extend_or_combine(self, rhs, mode, operation=op_iadd):
@@ -548,7 +547,7 @@ class Operator(object):
         Returns:
             [QuantumCircuit]: the circuits for evaluation.
         """
-        if QuantumDevice.is_statevector_backend(backend):
+        if QuantumExpConfig.is_statevector_backend(backend):
             if operator_mode == 'matrix':
                 circuits = [input_circuit]
             else:
@@ -636,7 +635,7 @@ class Operator(object):
             float: the standard deviation
         """
         avg, std_dev, variance = 0.0, 0.0, 0.0
-        if QuantumDevice.is_statevector_backend(backend):
+        if QuantumExpConfig.is_statevector_backend(backend):
             if operator_mode == "matrix":
                 self._check_representation("matrix")
                 if self._dia_matrix is None:
@@ -759,7 +758,7 @@ class Operator(object):
             avg = self._eval_directly(input_circuit)
             std_dev = 0.0
         else:
-            if QuantumDevice.is_statevector_backend(backend):
+            if QuantumExpConfig.is_statevector_backend(backend):
                 run_config['shots'] = 1
                 has_shared_circuits = True
 

--- a/qiskit_aqua/operator.py
+++ b/qiskit_aqua/operator.py
@@ -31,7 +31,7 @@ from qiskit import ClassicalRegister, QuantumCircuit
 from qiskit.quantum_info import Pauli
 from qiskit.qasm import pi
 
-from qiskit_aqua import AquaError, QuantumExpConfig
+from qiskit_aqua import AquaError, QuantumInstance
 from qiskit_aqua.utils import PauliGraph, compile_and_run_circuits, find_regs_by_name
 
 logger = logging.getLogger(__name__)
@@ -547,7 +547,7 @@ class Operator(object):
         Returns:
             [QuantumCircuit]: the circuits for evaluation.
         """
-        if QuantumExpConfig.is_statevector_backend(backend):
+        if QuantumInstance.is_statevector_backend(backend):
             if operator_mode == 'matrix':
                 circuits = [input_circuit]
             else:
@@ -635,7 +635,7 @@ class Operator(object):
             float: the standard deviation
         """
         avg, std_dev, variance = 0.0, 0.0, 0.0
-        if QuantumExpConfig.is_statevector_backend(backend):
+        if QuantumInstance.is_statevector_backend(backend):
             if operator_mode == "matrix":
                 self._check_representation("matrix")
                 if self._dia_matrix is None:
@@ -758,7 +758,7 @@ class Operator(object):
             avg = self._eval_directly(input_circuit)
             std_dev = 0.0
         else:
-            if QuantumExpConfig.is_statevector_backend(backend):
+            if QuantumInstance.is_statevector_backend(backend):
                 run_config['shots'] = 1
                 has_shared_circuits = True
 

--- a/qiskit_aqua/parser/input_schema.json
+++ b/qiskit_aqua/parser/input_schema.json
@@ -49,16 +49,8 @@
                     "type": ["object", "null"],
                     "default": null
                 },
-                "coupling_map": {
-                    "type": ["object", "null"],
-                    "default": null
-                },
                 "initial_layout": {
                     "type": ["object", "null"],
-                    "default": null
-                },
-                "basis_gates": {
-                    "type": ["string", "null"],
                     "default": null
                 },
                 "max_credits": {

--- a/qiskit_aqua/quantum_device.py
+++ b/qiskit_aqua/quantum_device.py
@@ -108,6 +108,11 @@ class QuantumDevice:
         logger.info(self)
 
     def __str__(self):
+        """Overload string.
+
+        Retruns:
+            str: the info of the object.
+        """
         info = 'Qiskit Terra version {}\n'.format(terra_version)
         info += "Backend '{}', with following setting:\n{}\n{}\n{}\n{}".format(
             self.backend_name, self._backend_config, self._compile_config,

--- a/qiskit_aqua/quantum_device.py
+++ b/qiskit_aqua/quantum_device.py
@@ -1,0 +1,272 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2018 IBM.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# =============================================================================
+
+import logging
+
+from qiskit import __version__ as terra_version
+import qiskit
+from qiskit.backends.ibmq.credentials import Credentials
+from qiskit.backends.ibmq.ibmqsingleprovider import IBMQSingleProvider
+
+from qiskit_aqua_cmd import Preferences
+from qiskit_aqua.utils import compile_and_run_circuits
+
+logger = logging.getLogger(__name__)
+
+
+class QuantumDevice:
+    """Quantum Backend including execution setting."""
+
+    UNSUPPORTED_BACKENDS = [
+        'unitary_simulator', 'clifford_simulator']
+
+    EQUIVALENT_BACKENDS = {'statevector_simulator_py': 'statevector_simulator',
+                           'statevector_simulator_sympy': 'statevector_simulator',
+                           'statevector_simulator_projectq': 'statevector_simulator',
+                           'qasm_simulator_py': 'qasm_simulator',
+                           'qasm_simulator_projectq': 'qasm_simulator'
+                           }
+
+    # TODO, other config setting.
+    def __init__(self, backend, basis_gates=None, coupling_map=None,
+                 initial_layout=None, shots=1024, max_credits=10, seed=None,
+                 qobj_id=None, hpc=None,
+                 noise_params=None, pass_manager=None, seed_mapper=None,
+                 timeout=None, wait=5, **kwargs):
+        """Constructor.
+
+        Args:
+            backend (BaseBackend): name of or instance of selected backend
+            shots (int): number of shots for the backend
+            pass_manager (PassManager): pass manager to handle how to compile the circuits
+            noise_params (dict): the noise setting for simulator
+            coupling_map (list): coupling map (perhaps custom) to target in mapping
+            initial_layout (dict): initial layout of qubits in mapping
+            hpc (dict): HPC simulator parameters
+            basis_gates (str): comma-separated basis gate set to compile to
+            max_credits (int): maximum credits to use
+            timeout (float or None): seconds to wait for job. If None, wait indefinitely.
+            wait (float): seconds between queries to result
+        Raises:
+            AlgorithmError: set backend with invalid Qconfig
+        """
+        self._backend = backend
+
+        if self.is_statevector and shots != 1:
+            logger.warning("statevector backend only works with shot=1, change "
+                           "shots from {} to 1.".format(shots))
+            shots = 1
+        if not self.is_simulator and noise_params is not None:
+            logger.warning("for a non-simulator backend, you can not set noise, change to None.")
+            noise_params = None
+        if coupling_map is None:
+            coupling_map = getattr(backend.configuration(), 'coupling_map', None)
+        if basis_gates is None:
+            basis_gates = backend.configuration().basis_gates
+            basis_gates = ','.join(basis_gates)
+
+        self._compile_config = {
+            'pass_manager': pass_manager,
+            'initial_layout': initial_layout,
+            'seed_mapper': seed_mapper,
+            'qobj_id': None
+        }
+
+        self._run_config = {
+            'shots': shots,
+            'max_credits': max_credits,
+            'hpc': hpc,
+        }
+
+        self._backend_config = {
+            'basis_gates': basis_gates,
+            'config': {"noise_params": noise_params},
+            'coupling_map': coupling_map,
+            'seed': seed
+        }
+
+        # setup job config
+        self._qjob_config = {'timeout': timeout} if self.is_local \
+            else {'timeout': timeout, 'wait': wait}
+
+        info = "Backend '{}', with following setting:\n{}\n{}\n{}\n{}".format(
+            self.backend_name, self._backend_config, self._compile_config,
+            self._run_config, self._qjob_config)
+
+        logger.info('Qiskit Terra version {}'.format(terra_version))
+        logger.info(info)
+
+        self._shared_circuits = False
+        self._circuit_summary = False
+
+    def execute(self, circuits):
+        """
+        A wrapper to interface with quantum backend.
+
+        Args:
+            circuits (QuantumCircuit or list[QuantumCircuit]): circuits to execute
+
+        Returns:
+            Result: Result object
+        """
+        result = compile_and_run_circuits(circuits, self._backend, self._backend_config, self._compile_config, self._run_config, self._qjob_config, show_circuit_summary=self._circuit_summary, has_shared_circuits=self._shared_circuits)
+        if self._circuit_summary:
+            self._circuit_summary = False
+
+        return result
+
+    @property
+    def shots(self):
+        return self._run_config['shots']
+
+    @shots.setter
+    def shots(self, new_value):
+        self._run_config['shots'] = new_value
+
+    # @property
+    # def execute_config(self):
+    #     return self._execute_config
+
+    # @execute_config.setter
+    # def execute_config(self, new_value):
+    #     self._execute_config = new_value
+
+    # @property
+    # def qjob_config(self):
+    #     return self._qjob_config
+
+    # @qjob_config.setter
+    # def qjob_config(self, new_value):
+    #     self._qjob_config = new_value
+
+    @property
+    def shared_circuits(self):
+        return self._has_shared_circuits
+
+    @shared_circuits.setter
+    def shared_circuits(self, new_value):
+        self._shared_circuits = new_value
+
+    @property
+    def circuit_summary(self):
+        return self._circuit_summary
+
+    @circuit_summary.setter
+    def circuit_summary(self, new_value):
+        self._circuit_summary = new_value
+
+    @property
+    def backend(self):
+        """Return BaseBackend backend object"""
+        return self._backend
+
+    @property
+    def backend_name(self):
+        return self._backend.name()
+
+    @property
+    def is_statevector(self):
+        """Returns True if backend is a statevector-type simulator."""
+        return QuantumDevice.is_statevector_backend(self._backend)
+
+    @property
+    def is_simulator(self):
+        """Returns True if backend is a simulator."""
+        return QuantumDevice.is_simulator_backend(self._backend)
+
+    @property
+    def is_local(self):
+        """Returns True if backend is a local backend."""
+        return QuantumDevice.is_local_backend(self._backend)
+
+    @staticmethod
+    def is_statevector_backend(backend):
+        """
+        Returns True if backend object is statevector.
+
+        Args:
+            backend (BaseBackend): backend instance
+        Returns:
+            Result (Boolean): True is statevector
+        """
+        return backend.name().startswith('statevector') if backend is not None else False
+
+    @staticmethod
+    def is_simulator_backend(backend):
+        """
+        Returns True if backend is a simulator.
+
+        Args:
+            backend (BaseBackend): backend instance
+        Returns:
+            Result (Boolean): True is a simulator
+        """
+        return backend.configuration().simulator
+
+    @staticmethod
+    def is_local_backend(backend):
+        """
+        Returns True if backend is a local backend.
+
+        Args:
+            backend (BaseBackend): backend instance
+        Returns:
+            Result (Boolean): True is a local backend
+        """
+        return backend.configuration().local
+
+    @staticmethod
+    def register_and_get_operational_backends():
+        # update registration info using internal methods because:
+        # at this point I don't want to save to or removecredentials from disk
+        # I want to update url, proxies etc without removing token and
+        # re-adding in 2 methods
+
+        ibmq_backends = []
+        try:
+            credentials = None
+            preferences = Preferences()
+            url = preferences.get_url()
+            token = preferences.get_token()
+            if url is not None and url != '' and token is not None and token != '':
+                credentials = Credentials(token,
+                                          url,
+                                          proxies=preferences.get_proxies({}))
+            if credentials is not None:
+                qiskit.IBMQ._accounts[credentials.unique_id()] = IBMQSingleProvider(
+                    credentials, qiskit.IBMQ)
+                logger.debug("Registered with Qiskit successfully.")
+                ibmq_backends = [x.name()
+                                 for x in qiskit.IBMQ.backends(url=url, token=token)]
+        except Exception as e:
+            logger.debug(
+                "Failed to register with Qiskit: {}".format(str(e)))
+
+        backends = set()
+        aer_backends = [x.name() for x in qiskit.Aer.backends()]
+        for aer_backend in aer_backends:
+            backend = aer_backend
+            supported = True
+            for unsupported_backend in QuantumDevice.UNSUPPORTED_BACKENDS:
+                if backend.startswith(unsupported_backend):
+                    supported = False
+                    break
+
+            if supported:
+                backends.add(backend)
+
+        return list(backends) + ibmq_backends

--- a/qiskit_aqua/quantum_device.py
+++ b/qiskit_aqua/quantum_device.py
@@ -18,7 +18,7 @@
 import logging
 
 from qiskit import __version__ as terra_version
-import qiskit
+from qiskit import IBMQ, Aer
 from qiskit.backends.ibmq.credentials import Credentials
 from qiskit.backends.ibmq.ibmqsingleprovider import IBMQSingleProvider
 
@@ -71,8 +71,8 @@ class QuantumDevice:
         self._backend = backend
 
         if self.is_statevector and shots != 1:
-            logger.warning("statevector backend only works with shot=1, change "
-                           "shots from {} to 1.".format(shots))
+            logger.info("statevector backend only works with shot=1, change "
+                        "shots from {} to 1.".format(shots))
             shots = 1
 
         coupling_map = getattr(backend.configuration(), 'coupling_map', None)
@@ -245,6 +245,16 @@ class QuantumDevice:
         """
         return backend.configuration().local
 
+    @classmethod
+    def get_quantum_device_with_aer_statevector_simulator(cls):
+        backend = Aer.get_backend('statevector_simulator')
+        return cls(backend)
+
+    @classmethod
+    def get_quantum_device_with_aer_qasm_simulator(cls, shots=1024):
+        backend = Aer.get_backend('qasm_simulator')
+        return cls(backend, shots=shots)
+
     @staticmethod
     def register_and_get_operational_backends():
         # update registration info using internal methods because:
@@ -263,17 +273,17 @@ class QuantumDevice:
                                           url,
                                           proxies=preferences.get_proxies({}))
             if credentials is not None:
-                qiskit.IBMQ._accounts[credentials.unique_id()] = IBMQSingleProvider(
-                    credentials, qiskit.IBMQ)
+                IBMQ._accounts[credentials.unique_id()] = IBMQSingleProvider(
+                    credentials, IBMQ)
                 logger.debug("Registered with Qiskit successfully.")
                 ibmq_backends = [x.name()
-                                 for x in qiskit.IBMQ.backends(url=url, token=token)]
+                                 for x in IBMQ.backends(url=url, token=token)]
         except Exception as e:
             logger.debug(
                 "Failed to register with Qiskit: {}".format(str(e)))
 
         backends = set()
-        aer_backends = [x.name() for x in qiskit.Aer.backends()]
+        aer_backends = [x.name() for x in Aer.backends()]
         for aer_backend in aer_backends:
             backend = aer_backend
             supported = True

--- a/qiskit_aqua/quantum_device.py
+++ b/qiskit_aqua/quantum_device.py
@@ -143,9 +143,21 @@ class QuantumDevice:
     # def execute_config(self, new_value):
     #     self._execute_config = new_value
 
-    # @property
-    # def qjob_config(self):
-    #     return self._qjob_config
+    @property
+    def qjob_config(self):
+        return self._qjob_config
+
+    @property
+    def backend_config(self):
+        return self._backend_config
+
+    @property
+    def compile_config(self):
+        return self._compile_config
+
+    @property
+    def run_config(self):
+        return self._run_config
 
     # @qjob_config.setter
     # def qjob_config(self, new_value):

--- a/qiskit_aqua/quantum_device.py
+++ b/qiskit_aqua/quantum_device.py
@@ -46,9 +46,10 @@ class QuantumDevice:
     RUN_CONFIG = ['shots', 'max_credits']
     QJOB_CONFIG = ['timeout', 'wait']
 
-    SIMULATOR_CONFIG = ["max_memory", "max_threads_shot", "max_threads_gate",
-                        "threshold_omp_gate", "data", "initial_state",
-                        "target_states", "renom_target_states", "chop", "noise_params"]
+    #  based on table at https://github.com/Qiskit/qiskit-terra/tree/master/src/qasm-simulator-cpp#table-of-config-options
+    SIMULATOR_CONFIG = ["shots_threads", "data", "noise_params", "initial_state",
+                        "target_states", "renom_target_states", "chop",
+                        "max_memory", "max_threads_shot", "max_threads_gate", "threshold_omp_gate"]
 
     def __init__(self, backend, shots=1024, max_credits=10, config=None, seed=None,
                  initial_layout=None, pass_manager=None, seed_mapper=None,

--- a/qiskit_aqua/quantum_exp_config.py
+++ b/qiskit_aqua/quantum_exp_config.py
@@ -28,7 +28,7 @@ from qiskit_aqua.utils import compile_and_run_circuits
 logger = logging.getLogger(__name__)
 
 
-class QuantumDevice:
+class QuantumExpConfig:
     """Quantum Backend including execution setting."""
 
     UNSUPPORTED_BACKENDS = [
@@ -141,15 +141,15 @@ class QuantumDevice:
 
     def set_config(self, **kwargs):
         for k, v in kwargs.items():
-            if k in QuantumDevice.RUN_CONFIG:
+            if k in QuantumExpConfig.RUN_CONFIG:
                 self._run_config[k] = v
-            elif k in QuantumDevice.QJOB_CONFIG:
+            elif k in QuantumExpConfig.QJOB_CONFIG:
                 self._qjob_config[k] = v
-            elif k in QuantumDevice.COMPILE_CONFIG:
+            elif k in QuantumExpConfig.COMPILE_CONFIG:
                 self._compile_config[k] = v
-            elif k in QuantumDevice.BACKEND_CONFIG:
+            elif k in QuantumExpConfig.BACKEND_CONFIG:
                 self._backend_config[k] = v
-            elif k in QuantumDevice.SIMULATOR_CONFIG:
+            elif k in QuantumExpConfig.SIMULATOR_CONFIG:
                 self._backend_config['config'][k] = v
             else:
                 raise ValueError("unknown setting for the key ({}).".format(k))
@@ -197,17 +197,17 @@ class QuantumDevice:
     @property
     def is_statevector(self):
         """Return True if backend is a statevector-type simulator."""
-        return QuantumDevice.is_statevector_backend(self._backend)
+        return QuantumExpConfig.is_statevector_backend(self._backend)
 
     @property
     def is_simulator(self):
         """Return True if backend is a simulator."""
-        return QuantumDevice.is_simulator_backend(self._backend)
+        return QuantumExpConfig.is_simulator_backend(self._backend)
 
     @property
     def is_local(self):
         """Return True if backend is a local backend."""
-        return QuantumDevice.is_local_backend(self._backend)
+        return QuantumExpConfig.is_local_backend(self._backend)
 
     @staticmethod
     def is_statevector_backend(backend):
@@ -246,12 +246,12 @@ class QuantumDevice:
         return backend.configuration().local
 
     @classmethod
-    def get_quantum_device_with_aer_statevector_simulator(cls):
+    def get_quantum_exp_config_with_aer_statevector_simulator(cls):
         backend = Aer.get_backend('statevector_simulator')
         return cls(backend)
 
     @classmethod
-    def get_quantum_device_with_aer_qasm_simulator(cls, shots=1024):
+    def get_quantum_exp_config_with_aer_qasm_simulator(cls, shots=1024):
         backend = Aer.get_backend('qasm_simulator')
         return cls(backend, shots=shots)
 
@@ -287,7 +287,7 @@ class QuantumDevice:
         for aer_backend in aer_backends:
             backend = aer_backend
             supported = True
-            for unsupported_backend in QuantumDevice.UNSUPPORTED_BACKENDS:
+            for unsupported_backend in QuantumExpConfig.UNSUPPORTED_BACKENDS:
                 if backend.startswith(unsupported_backend):
                     supported = False
                     break

--- a/qiskit_aqua/quantum_instance.py
+++ b/qiskit_aqua/quantum_instance.py
@@ -28,7 +28,7 @@ from qiskit_aqua.utils import compile_and_run_circuits
 logger = logging.getLogger(__name__)
 
 
-class QuantumExpConfig:
+class QuantumInstance:
     """Quantum Backend including execution setting."""
 
     UNSUPPORTED_BACKENDS = [

--- a/qiskit_aqua/quantum_instance.py
+++ b/qiskit_aqua/quantum_instance.py
@@ -141,15 +141,15 @@ class QuantumInstance:
 
     def set_config(self, **kwargs):
         for k, v in kwargs.items():
-            if k in QuantumExpConfig.RUN_CONFIG:
+            if k in QuantumInstance.RUN_CONFIG:
                 self._run_config[k] = v
-            elif k in QuantumExpConfig.QJOB_CONFIG:
+            elif k in QuantumInstance.QJOB_CONFIG:
                 self._qjob_config[k] = v
-            elif k in QuantumExpConfig.COMPILE_CONFIG:
+            elif k in QuantumInstance.COMPILE_CONFIG:
                 self._compile_config[k] = v
-            elif k in QuantumExpConfig.BACKEND_CONFIG:
+            elif k in QuantumInstance.BACKEND_CONFIG:
                 self._backend_config[k] = v
-            elif k in QuantumExpConfig.SIMULATOR_CONFIG:
+            elif k in QuantumInstance.SIMULATOR_CONFIG:
                 self._backend_config['config'][k] = v
             else:
                 raise ValueError("unknown setting for the key ({}).".format(k))
@@ -197,17 +197,17 @@ class QuantumInstance:
     @property
     def is_statevector(self):
         """Return True if backend is a statevector-type simulator."""
-        return QuantumExpConfig.is_statevector_backend(self._backend)
+        return QuantumInstance.is_statevector_backend(self._backend)
 
     @property
     def is_simulator(self):
         """Return True if backend is a simulator."""
-        return QuantumExpConfig.is_simulator_backend(self._backend)
+        return QuantumInstance.is_simulator_backend(self._backend)
 
     @property
     def is_local(self):
         """Return True if backend is a local backend."""
-        return QuantumExpConfig.is_local_backend(self._backend)
+        return QuantumInstance.is_local_backend(self._backend)
 
     @staticmethod
     def is_statevector_backend(backend):
@@ -287,7 +287,7 @@ class QuantumInstance:
         for aer_backend in aer_backends:
             backend = aer_backend
             supported = True
-            for unsupported_backend in QuantumExpConfig.UNSUPPORTED_BACKENDS:
+            for unsupported_backend in QuantumInstance.UNSUPPORTED_BACKENDS:
                 if backend.startswith(unsupported_backend):
                     supported = False
                     break

--- a/qiskit_aqua/quantum_instance.py
+++ b/qiskit_aqua/quantum_instance.py
@@ -153,6 +153,7 @@ class QuantumInstance:
                 self._backend_config['config'][k] = v
             else:
                 raise ValueError("unknown setting for the key ({}).".format(k))
+
     @property
     def qjob_config(self):
         return self._qjob_config
@@ -245,16 +246,6 @@ class QuantumInstance:
         """
         return backend.configuration().local
 
-    @classmethod
-    def get_quantum_exp_config_with_aer_statevector_simulator(cls):
-        backend = Aer.get_backend('statevector_simulator')
-        return cls(backend)
-
-    @classmethod
-    def get_quantum_exp_config_with_aer_qasm_simulator(cls, shots=1024):
-        backend = Aer.get_backend('qasm_simulator')
-        return cls(backend, shots=shots)
-
     @staticmethod
     def register_and_get_operational_backends():
         # update registration info using internal methods because:
@@ -296,3 +287,13 @@ class QuantumInstance:
                 backends.add(backend)
 
         return list(backends) + ibmq_backends
+
+
+def get_quantum_exp_config_with_aer_statevector_simulator():
+    backend = Aer.get_backend('statevector_simulator')
+    return QuantumInstance(backend)
+
+
+def get_quantum_exp_config_with_aer_qasm_simulator(shots=1024):
+    backend = Aer.get_backend('qasm_simulator')
+    return QuantumInstance(backend, shots=shots)

--- a/qiskit_aqua/utils/__init__.py
+++ b/qiskit_aqua/utils/__init__.py
@@ -29,7 +29,7 @@ from .dataset_helper import (get_feature_dimension, get_num_classes,
                              split_dataset_to_data_and_labels, map_label_to_class_name,
                              reduce_dim_to_via_pca)
 from .qpsolver import optimize_svm
-from .run_circuits import run_circuits, find_regs_by_name
+from .run_circuits import compile_and_run_circuits, find_regs_by_name
 
 __all__ = ['tensorproduct',
            'PauliGraph',
@@ -51,5 +51,5 @@ __all__ = ['tensorproduct',
            'map_label_to_class_name',
            'reduce_dim_to_via_pca',
            'optimize_svm',
-           'run_circuits',
+           'compile_and_run_circuits',
            'find_regs_by_name']

--- a/qiskit_aqua/utils/run_circuits.py
+++ b/qiskit_aqua/utils/run_circuits.py
@@ -26,10 +26,13 @@ from qiskit.backends import BaseBackend
 from qiskit import compile as q_compile
 from qiskit.backends.jobstatus import JobStatus
 from qiskit.backends import JobError
+from qiskit import transpiler
+from qiskit.tools._compiler import circuits_to_qobj
+
 
 from qiskit_aqua.aqua_error import AquaError
 from qiskit_aqua.utils import summarize_circuits
-from qiskit_aqua.algorithms import QuantumAlgorithm
+
 
 logger = logging.getLogger(__name__)
 
@@ -67,13 +70,13 @@ def _avoid_empty_circuits(circuits):
                 tmp_q = q
                 break
             if tmp_q is None:
-                raise AquaError("A QASM without any quantum register is invalid.")
+                raise NameError("A QASM without any quantum register is invalid.")
             qc.iden(tmp_q[0])
         new_circuits.append(qc)
     return new_circuits
 
 
-def _reuse_shared_circuits(circuits, backend, execute_config, qjob_config=None):
+def _reuse_shared_circuits(circuits, backend, backend_config, compile_config, run_config, qjob_config=None):
     """Reuse the circuits with the shared head.
 
     We assume the 0-th circuit is the shared_circuit, so we execute it first
@@ -89,7 +92,7 @@ def _reuse_shared_circuits(circuits, backend, execute_config, qjob_config=None):
     qjob_config = qjob_config or {}
 
     shared_circuit = circuits[0]
-    shared_result = run_circuits(shared_circuit, backend, execute_config,
+    shared_result = compile_and_run_circuits(shared_circuit, backend, run_config,
                                  show_circuit_summary=True)
 
     if len(circuits) == 1:
@@ -99,16 +102,32 @@ def _reuse_shared_circuits(circuits, backend, execute_config, qjob_config=None):
     for circuit in circuits[1:]:
         circuit.data = circuit.data[len(shared_circuit):]
 
-    temp_execute_config = copy.deepcopy(execute_config)
-    if 'config' not in temp_execute_config:
-        temp_execute_config['config'] = dict()
-    temp_execute_config['config']['initial_state'] = shared_quantum_state
-    diff_result = run_circuits(circuits[1:], backend, temp_execute_config, qjob_config)
+    temp_run_config = copy.deepcopy(run_config)
+    if 'config' not in temp_run_config:
+        temp_run_config['config'] = dict()
+    temp_run_config['config']['initial_state'] = shared_quantum_state
+    diff_result = compile_and_run_circuits(circuits[1:], backend, temp_run_config, qjob_config)
     result = shared_result + diff_result
     return result
 
 
-def run_circuits(circuits, backend, execute_config, qjob_config=None,
+def _terra_compile_with_pass_manager(circuits, backend, config=None, basis_gates=None,
+                                     coupling_map=None, initial_layout=None,
+                                     shots=1024, max_credits=10, seed=None, qobj_id=None, hpc=None,
+                                     pass_manager=None, seed_mapper=None):
+
+    circuits = transpiler.transpile(circuits, backend, basis_gates, coupling_map, initial_layout,
+                                    seed_mapper, hpc, pass_manager)
+
+    qobj = circuits_to_qobj(circuits, backend_name=backend.name(),
+                            config=config, shots=shots, max_credits=max_credits,
+                            qobj_id=qobj_id, basis_gates=basis_gates,
+                            coupling_map=coupling_map, seed=seed)
+
+    return qobj
+
+
+def compile_and_run_circuits(circuits, backend, backend_config, compile_config, run_config, qjob_config,
                  show_circuit_summary=False, has_shared_circuits=False):
     """
     An execution wrapper with Qiskit-Terra, with job auto recover capability.
@@ -119,8 +138,10 @@ def run_circuits(circuits, backend, execute_config, qjob_config=None,
     Args:
         circuits (QuantumCircuit or list[QuantumCircuit]): circuits to execute
         backend (BaseBackend): backend instance
-        execute_config (dict): settings for qiskit execute (or compile)
-        qjob_config (dict): settings for job object, like timeout and wait
+        backend_config (dict): configuration for backend
+        compile_config (dict): configuration for compilation
+        run_config (dict): configuration for running a circuit
+        qjob_config (dict): configuration for quantum job object
         show_circuit_summary (bool): showing the summary of submitted circuits.
         has_shared_circuits (bool): use the 0-th circuits as initial state for other circuits.
     Returns:
@@ -133,22 +154,22 @@ def run_circuits(circuits, backend, execute_config, qjob_config=None,
     qjob_config = qjob_config or {}
 
     if backend is None or not isinstance(backend, BaseBackend):
-        raise AquaError('Backend is missing or not an instance of BaseBackend')
+        raise ValueError('Backend is missing or not an instance of BaseBackend')
 
     if not isinstance(circuits, list):
         circuits = [circuits]
 
-    if QuantumAlgorithm.is_statevector_backend(backend):
+    if 'statevector' in backend.name():
         circuits = _avoid_empty_circuits(circuits)
 
     if has_shared_circuits:
-        return _reuse_shared_circuits(circuits, backend, execute_config, qjob_config)
+        return _reuse_shared_circuits(circuits, backend, backend_config, compile_config, run_config, qjob_config)
 
     with_autorecover = False if backend.configuration().simulator else True
     max_circuits_per_job = sys.maxsize if backend.configuration().local else MAX_CIRCUITS_PER_JOB
 
-    support_qobj = backend.configuration().get('allow_q_object', False)
-    job_completed_signature = 'COMPLETED' if not support_qobj else 'Successful completion'
+    # support_qobj = backend.configuration().get('allow_q_object', False)
+    # job_completed_signature = 'COMPLETED' if not support_qobj else 'Successful completion'
 
     qobjs = []
     jobs = []
@@ -157,7 +178,11 @@ def run_circuits(circuits, backend, execute_config, qjob_config=None,
     for i in range(chunks):
         sub_circuits = circuits[i *
                                 max_circuits_per_job:(i + 1) * max_circuits_per_job]
-        qobj = q_compile(sub_circuits, backend, **execute_config)
+        compile_config.pop('pass_manager', None)
+        # qobj = q_compile(sub_circuits, backend, **backend_config,
+        #                                         **compile_config, **run_config)
+        qobj = _terra_compile_with_pass_manager(sub_circuits, backend, **backend_config,
+                                                **compile_config, **run_config)
         job = backend.run(qobj)
         jobs.append(job)
         qobjs.append(qobj)
@@ -179,7 +204,7 @@ def run_circuits(circuits, backend, execute_config, qjob_config=None,
             while True:
                 try:
                     result = job.result(**qjob_config)
-                    if result.status == job_completed_signature:
+                    if result.success:
                         results.append(result)
                         logger.info("COMPLETED the {}-th chunk of circuits, "
                                     "job id: {}".format(idx, job_id))
@@ -193,7 +218,7 @@ def run_circuits(circuits, backend, execute_config, qjob_config=None,
                                    "Terra job error: {} ".format(idx, job_id, e))
                 except Exception as e:
                     raise AquaError("FAILURE: the {}-th chunk of circuits, job id: {}, "
-                                         "Terra unknown error: {} ".format(idx, job_id, e)) from e
+                                    "Terra unknown error: {} ".format(idx, job_id, e)) from e
 
                 # keep querying the status until it is okay.
                 while True:
@@ -207,8 +232,8 @@ def run_circuits(circuits, backend, execute_config, qjob_config=None,
                         time.sleep(5)
                     except Exception as e:
                         raise AquaError("FAILURE: job id: {}, "
-                                             "status: 'FAIL_TO_GET_STATUS' "
-                                             "({})".format(job_id, e)) from e
+                                        "status: 'FAIL_TO_GET_STATUS' "
+                                        "({})".format(job_id, e)) from e
 
                 logger.info("Job status: {}".format(job_status))
                 # when reach here, it means the job fails. let's check what kinds of failure it is.

--- a/qiskit_aqua/utils/summarize_circuits.py
+++ b/qiskit_aqua/utils/summarize_circuits.py
@@ -16,12 +16,11 @@
 # =============================================================================
 
 import numpy as np
-from qiskit.dagcircuit import DAGCircuit
+
 
 def summarize_circuits(circuits):
-    """
+    """Summarize circuits based on QuantumCircuit, and four metrics are summarized.
 
-    Summarize circuits based on DAGCircuit, and four metrics are summarized.
     Number of qubits and classical bits, and number of operations and depth of circuits.
     The average statistic is provided if multiple circuits are inputed.
 
@@ -32,22 +31,24 @@ def summarize_circuits(circuits):
     if not isinstance(circuits, list):
         circuits = [circuits]
     ret = ""
-    dag_circuits = [DAGCircuit.fromQuantumCircuit(circuit) for circuit in circuits]
-    ret += "Submitting {} circuits.\n".format(len(dag_circuits))
+    ret += "Submitting {} circuits.\n".format(len(circuits))
     ret += "============================================================================\n"
     stats = np.zeros(4)
-    for i, dag_circuit in enumerate(dag_circuits):
-        depth = dag_circuit.depth()
-        width = dag_circuit.width()
-        size = dag_circuit.size()
-        classical_bits = dag_circuit.num_cbits()
+    for i, circuit in enumerate(circuits):
+        depth = circuit.depth()
+        width = circuit.width()
+        size = circuit.size()
+        classical_bits = circuit.num_cbits()
+        op_counts = circuit.count_ops()
         stats[0] += width
         stats[1] += classical_bits
         stats[2] += size
         stats[3] += depth
-        ret += "{}-th circuit: {} qubits, {} classical bits and {} operations with depth {}\n".format(i, width, classical_bits, size, depth)
-    if len(dag_circuits) > 1:
-        stats /= len(dag_circuits)
-        ret += "Average: {:.2f} qubits, {:.2f} classical bits and {:.2f} operations with depth {:.2f}\n".format(stats[0], stats[1], stats[2], stats[3])
+        ret = ''.join([ret, "{}-th circuit: {} qubits, {} classical bits and {} operations with depth {}\n op_counts: {}\n".format(
+            i, width, classical_bits, size, depth, op_counts)])
+    if len(circuits) > 1:
+        stats /= len(circuits)
+        ret = ''.join([ret, "Average: {:.2f} qubits, {:.2f} classical bits and {:.2f} operations with depth {:.2f}\n".format(
+            stats[0], stats[1], stats[2], stats[3])])
     ret += "============================================================================\n"
     return ret

--- a/test/test_eoh.py
+++ b/test/test_eoh.py
@@ -49,7 +49,7 @@ class TestEOH(QiskitAquaTestCase):
         eoh = EOH(qubit_op, state_in, evo_op, 'paulis', evo_time, num_time_slices)
 
         backend = Aer.get_backend('statevector_simulator')
-        quantum_device = QuantumDevice(backend, pass_manager=PassManager(), shots=1)
+        quantum_device = QuantumDevice(backend, pass_manager=PassManager())
         # self.log.debug('state_out:\n\n')
 
         ret = eoh.run(quantum_device)

--- a/test/test_eoh.py
+++ b/test/test_eoh.py
@@ -49,7 +49,7 @@ class TestEOH(QiskitAquaTestCase):
         eoh = EOH(qubit_op, state_in, evo_op, 'paulis', evo_time, num_time_slices)
 
         backend = Aer.get_backend('statevector_simulator')
-        quantum_device = QuantumDevice(backend, pass_manager=PassManager())
+        quantum_device = QuantumDevice(backend, pass_manager=PassManager(), shots=1)
         # self.log.debug('state_out:\n\n')
 
         ret = eoh.run(quantum_device)

--- a/test/test_eoh.py
+++ b/test/test_eoh.py
@@ -19,9 +19,10 @@ import unittest
 
 import numpy as np
 from qiskit.transpiler import PassManager
+from qiskit import Aer
 
 from test.common import QiskitAquaTestCase
-from qiskit_aqua.operator import Operator
+from qiskit_aqua.operator import Operator, QuantumDevice
 from qiskit_aqua.algorithms.components.initial_states import Custom
 from qiskit_aqua.algorithms.many_sample import EOH
 
@@ -46,10 +47,12 @@ class TestEOH(QiskitAquaTestCase):
         num_time_slices = 100
 
         eoh = EOH(qubit_op, state_in, evo_op, 'paulis', evo_time, num_time_slices)
-        eoh.setup_quantum_backend(pass_manager=PassManager())
+
+        backend = Aer.get_backend('statevector_simulator')
+        quantum_device = QuantumDevice(backend, pass_manager=PassManager())
         # self.log.debug('state_out:\n\n')
 
-        ret = eoh.run()
+        ret = eoh.run(quantum_device)
         self.log.debug('Evaluation result: {}'.format(ret))
 
 

--- a/test/test_eoh.py
+++ b/test/test_eoh.py
@@ -22,7 +22,7 @@ from qiskit.transpiler import PassManager
 from qiskit import Aer
 
 from test.common import QiskitAquaTestCase
-from qiskit_aqua.operator import Operator, QuantumDevice
+from qiskit_aqua.operator import Operator, QuantumExpConfig
 from qiskit_aqua.algorithms.components.initial_states import Custom
 from qiskit_aqua.algorithms.many_sample import EOH
 
@@ -49,7 +49,7 @@ class TestEOH(QiskitAquaTestCase):
         eoh = EOH(qubit_op, state_in, evo_op, 'paulis', evo_time, num_time_slices)
 
         backend = Aer.get_backend('statevector_simulator')
-        quantum_device = QuantumDevice(backend, pass_manager=PassManager())
+        quantum_device = QuantumExpConfig(backend, pass_manager=PassManager())
         # self.log.debug('state_out:\n\n')
 
         ret = eoh.run(quantum_device)

--- a/test/test_eoh.py
+++ b/test/test_eoh.py
@@ -22,7 +22,7 @@ from qiskit.transpiler import PassManager
 from qiskit import Aer
 
 from test.common import QiskitAquaTestCase
-from qiskit_aqua.operator import Operator, QuantumExpConfig
+from qiskit_aqua.operator import Operator, QuantumInstance
 from qiskit_aqua.algorithms.components.initial_states import Custom
 from qiskit_aqua.algorithms.many_sample import EOH
 
@@ -49,10 +49,10 @@ class TestEOH(QiskitAquaTestCase):
         eoh = EOH(qubit_op, state_in, evo_op, 'paulis', evo_time, num_time_slices)
 
         backend = Aer.get_backend('statevector_simulator')
-        quantum_device = QuantumExpConfig(backend, pass_manager=PassManager())
+        quantum_instance = QuantumInstance(backend, pass_manager=PassManager())
         # self.log.debug('state_out:\n\n')
 
-        ret = eoh.run(quantum_device)
+        ret = eoh.run(quantum_instance)
         self.log.debug('Evaluation result: {}'.format(ret))
 
 

--- a/test/test_grover.py
+++ b/test/test_grover.py
@@ -24,7 +24,7 @@ from qiskit import Aer
 from test.common import QiskitAquaTestCase
 from qiskit_aqua.algorithms.components.oracles import SAT
 from qiskit_aqua.algorithms.single_sample import Grover
-from qiskit_aqua import QuantumExpConfig
+from qiskit_aqua import QuantumInstance
 
 
 class TestGrover(QiskitAquaTestCase):
@@ -59,9 +59,9 @@ class TestGrover(QiskitAquaTestCase):
         backend = Aer.get_backend('qasm_simulator')
         sat_oracle = SAT(buf)
         grover = Grover(sat_oracle, num_iterations=num_iterations, incremental=incremental)
-        quantum_device = QuantumExpConfig(backend, shots=100)
+        quantum_instance = QuantumInstance(backend, shots=100)
 
-        ret = grover.run(quantum_device)
+        ret = grover.run(quantum_instance)
 
         self.log.debug('Ground-truth Solutions: {}.'.format(self.groundtruth))
         self.log.debug('Measurement result:     {}.'.format(ret['measurements']))

--- a/test/test_grover.py
+++ b/test/test_grover.py
@@ -24,7 +24,7 @@ from qiskit import Aer
 from test.common import QiskitAquaTestCase
 from qiskit_aqua.algorithms.components.oracles import SAT
 from qiskit_aqua.algorithms.single_sample import Grover
-from qiskit_aqua import QuantumDevice
+from qiskit_aqua import QuantumExpConfig
 
 
 class TestGrover(QiskitAquaTestCase):
@@ -59,7 +59,7 @@ class TestGrover(QiskitAquaTestCase):
         backend = Aer.get_backend('qasm_simulator')
         sat_oracle = SAT(buf)
         grover = Grover(sat_oracle, num_iterations=num_iterations, incremental=incremental)
-        quantum_device = QuantumDevice(backend, shots=100)
+        quantum_device = QuantumExpConfig(backend, shots=100)
 
         ret = grover.run(quantum_device)
 

--- a/test/test_grover.py
+++ b/test/test_grover.py
@@ -24,6 +24,7 @@ from qiskit import Aer
 from test.common import QiskitAquaTestCase
 from qiskit_aqua.algorithms.components.oracles import SAT
 from qiskit_aqua.algorithms.single_sample import Grover
+from qiskit_aqua import QuantumDevice
 
 
 class TestGrover(QiskitAquaTestCase):
@@ -58,9 +59,9 @@ class TestGrover(QiskitAquaTestCase):
         backend = Aer.get_backend('qasm_simulator')
         sat_oracle = SAT(buf)
         grover = Grover(sat_oracle, num_iterations=num_iterations, incremental=incremental)
-        grover.setup_quantum_backend(backend=backend, shots=100)
+        quantum_device = QuantumDevice(backend, shots=100)
 
-        ret = grover.run()
+        ret = grover.run(quantum_device)
 
         self.log.debug('Ground-truth Solutions: {}.'.format(self.groundtruth))
         self.log.debug('Measurement result:     {}.'.format(ret['measurements']))

--- a/test/test_iqpe.py
+++ b/test/test_iqpe.py
@@ -25,7 +25,7 @@ from qiskit.transpiler import PassManager
 from qiskit import Aer
 
 from test.common import QiskitAquaTestCase
-from qiskit_aqua import Operator, QuantumDevice
+from qiskit_aqua import Operator, QuantumExpConfig
 from qiskit_aqua.utils import decimal_to_binary
 from qiskit_aqua.algorithms.single_sample import IQPE
 from qiskit_aqua.algorithms.classical import ExactEigensolver
@@ -84,7 +84,7 @@ class TestIQPE(QiskitAquaTestCase):
                     paulis_grouping='random', expansion_mode='suzuki', expansion_order=2)
 
         backend = Aer.get_backend('qasm_simulator')
-        quantum_device = QuantumDevice(backend, shots=100, pass_manager=PassManager())
+        quantum_device = QuantumExpConfig(backend, shots=100, pass_manager=PassManager())
 
         result = iqpe.run(quantum_device)
 

--- a/test/test_iqpe.py
+++ b/test/test_iqpe.py
@@ -25,7 +25,7 @@ from qiskit.transpiler import PassManager
 from qiskit import Aer
 
 from test.common import QiskitAquaTestCase
-from qiskit_aqua import Operator, QuantumExpConfig
+from qiskit_aqua import Operator, QuantumInstance
 from qiskit_aqua.utils import decimal_to_binary
 from qiskit_aqua.algorithms.single_sample import IQPE
 from qiskit_aqua.algorithms.classical import ExactEigensolver
@@ -84,9 +84,9 @@ class TestIQPE(QiskitAquaTestCase):
                     paulis_grouping='random', expansion_mode='suzuki', expansion_order=2)
 
         backend = Aer.get_backend('qasm_simulator')
-        quantum_device = QuantumExpConfig(backend, shots=100, pass_manager=PassManager())
+        quantum_instance = QuantumInstance(backend, shots=100, pass_manager=PassManager())
 
-        result = iqpe.run(quantum_device)
+        result = iqpe.run(quantum_instance)
 
         self.log.debug('top result str label:         {}'.format(result['top_measurement_label']))
         self.log.debug('top result in decimal:        {}'.format(result['top_measurement_decimal']))

--- a/test/test_iqpe.py
+++ b/test/test_iqpe.py
@@ -22,9 +22,10 @@ from parameterized import parameterized
 from scipy.linalg import expm
 from scipy import sparse
 from qiskit.transpiler import PassManager
+from qiskit import Aer
 
 from test.common import QiskitAquaTestCase
-from qiskit_aqua import Operator
+from qiskit_aqua import Operator, QuantumDevice
 from qiskit_aqua.utils import decimal_to_binary
 from qiskit_aqua.algorithms.single_sample import IQPE
 from qiskit_aqua.algorithms.classical import ExactEigensolver
@@ -81,9 +82,11 @@ class TestIQPE(QiskitAquaTestCase):
         state_in = Custom(self.qubitOp.num_qubits, state_vector=self.ref_eigenvec)
         iqpe = IQPE(self.qubitOp, state_in, num_time_slices, num_iterations,
                     paulis_grouping='random', expansion_mode='suzuki', expansion_order=2)
-        iqpe.setup_quantum_backend(backend='qasm_simulator', shots=100, pass_manager=PassManager())
 
-        result = iqpe.run()
+        backend = Aer.get_backend('qasm_simulator')
+        quantum_device = QuantumDevice(backend, shots=100, pass_manager=PassManager())
+
+        result = iqpe.run(quantum_device)
 
         self.log.debug('top result str label:         {}'.format(result['top_measurement_label']))
         self.log.debug('top result in decimal:        {}'.format(result['top_measurement_decimal']))

--- a/test/test_operator.py
+++ b/test/test_operator.py
@@ -46,13 +46,14 @@ class TestOperator(QiskitAquaTestCase):
         var_form = RYRZ(self.qubitOp.num_qubits, depth)
         circuit = var_form.construct_circuit(np.array(np.random.randn(var_form.num_parameters)))
         # self.qubitOp.coloring = None
-        execute_config_ref = {'shots': 1}
-        execute_config = {'shots': 10000}
-        reference = self.qubitOp.eval('matrix', circuit, Aer.get_backend('statevector_simulator'), execute_config_ref)[0]
+        run_config_ref = {'shots': 1}
+        run_config = {'shots': 10000}
+        reference = self.qubitOp.eval('matrix', circuit, Aer.get_backend(
+            'statevector_simulator'), run_config=run_config_ref)[0]
         reference = reference.real
         backend = Aer.get_backend('qasm_simulator')
-        paulis_mode = self.qubitOp.eval('paulis', circuit, backend, execute_config)
-        grouped_paulis_mode = self.qubitOp.eval('grouped_paulis', circuit, backend, execute_config)
+        paulis_mode = self.qubitOp.eval('paulis', circuit, backend, run_config=run_config)
+        grouped_paulis_mode = self.qubitOp.eval('grouped_paulis', circuit, backend, run_config=run_config)
 
         paulis_mode_p_3sigma = paulis_mode[0] + 3 * paulis_mode[1]
         paulis_mode_m_3sigma = paulis_mode[0] - 3 * paulis_mode[1]
@@ -64,9 +65,12 @@ class TestOperator(QiskitAquaTestCase):
         self.assertLessEqual(reference, grouped_paulis_mode_p_3sigma.real)
         self.assertGreaterEqual(reference, grouped_paulis_mode_m_3sigma.real)
 
-        execute_config = {'shots': 10000, 'pass_manager': PassManager()}
-        paulis_mode = self.qubitOp.eval('paulis', circuit, backend, execute_config)
-        grouped_paulis_mode = self.qubitOp.eval('grouped_paulis', circuit, backend, execute_config)
+        run_config = {'shots': 10000}
+        compile_config = {'pass_manager': PassManager()}
+        paulis_mode = self.qubitOp.eval('paulis', circuit, backend,
+                                        run_config=run_config, compile_config=compile_config)
+        grouped_paulis_mode = self.qubitOp.eval('grouped_paulis', circuit, backend,
+                                                run_config=run_config, compile_config=compile_config)
 
         paulis_mode_p_3sigma = paulis_mode[0] + 3 * paulis_mode[1]
         paulis_mode_m_3sigma = paulis_mode[0] - 3 * paulis_mode[1]
@@ -83,16 +87,19 @@ class TestOperator(QiskitAquaTestCase):
         var_form = RYRZ(self.qubitOp.num_qubits, depth)
         circuit = var_form.construct_circuit(np.array(np.random.randn(var_form.num_parameters)))
 
-        execute_config = {'shots': 1}
+        run_config = {'shots': 1}
         backend = Aer.get_backend('statevector_simulator')
-        matrix_mode = self.qubitOp.eval('matrix', circuit, backend, execute_config)[0]
-        non_matrix_mode = self.qubitOp.eval('paulis', circuit, backend, execute_config)[0]
+        matrix_mode = self.qubitOp.eval('matrix', circuit, backend, run_config=run_config)[0]
+        non_matrix_mode = self.qubitOp.eval('paulis', circuit, backend, run_config=run_config)[0]
         diff = abs(matrix_mode - non_matrix_mode)
         self.assertLess(diff, 0.01, "Values: ({} vs {})".format(matrix_mode, non_matrix_mode))
 
-        execute_config = {'shots': 1, 'pass_manager': PassManager()}
-        non_matrix_mode = self.qubitOp.eval('paulis', circuit, backend, execute_config)[0]
+        run_config = {'shots': 1}
+        compile_config = {'pass_manager': PassManager()}
+        non_matrix_mode = self.qubitOp.eval('paulis', circuit, backend,
+                                            run_config=run_config, compile_config=compile_config)[0]
         diff = abs(matrix_mode - non_matrix_mode)
+        print(matrix_mode, non_matrix_mode)
         self.assertLess(diff, 0.01, "Without any pass manager, Values: ({} vs {})".format(matrix_mode, non_matrix_mode))
 
     def test_create_from_paulis_0(self):
@@ -106,16 +113,16 @@ class TestOperator(QiskitAquaTestCase):
             depth = 1
             var_form = RYRZ(op.num_qubits, depth)
             circuit = var_form.construct_circuit(np.array(np.random.randn(var_form.num_parameters)))
-            execute_config = {'shots': 1}
+            run_config = {'shots': 1}
             backend = Aer.get_backend('statevector_simulator')
-            non_matrix_mode = op.eval('paulis', circuit, backend, execute_config)[0]
-            matrix_mode = op.eval('matrix', circuit, backend, execute_config)[0]
+            non_matrix_mode = op.eval('paulis', circuit, backend, run_config=run_config)[0]
+            matrix_mode = op.eval('matrix', circuit, backend, run_config=run_config)[0]
 
             self.assertAlmostEqual(matrix_mode, non_matrix_mode, 6)
 
     def test_create_from_matrix(self):
         """Test with matrix initialization."""
-        for num_qubits in range(1, 6):
+        for num_qubits in range(1, 3):
             m_size = np.power(2, num_qubits)
             matrix = np.random.rand(m_size, m_size)
 
@@ -125,9 +132,9 @@ class TestOperator(QiskitAquaTestCase):
             var_form = RYRZ(op.num_qubits, depth)
             circuit = var_form.construct_circuit(np.array(np.random.randn(var_form.num_parameters)))
             backend = Aer.get_backend('statevector_simulator')
-            execute_config = {'shots': 1}
-            non_matrix_mode = op.eval('paulis', circuit, backend, execute_config)[0]
-            matrix_mode = op.eval('matrix', circuit, backend, execute_config)[0]
+            run_config = {'shots': 1}
+            non_matrix_mode = op.eval('paulis', circuit, backend, run_config=run_config)[0]
+            matrix_mode = op.eval('matrix', circuit, backend, run_config=run_config)[0]
 
             self.assertAlmostEqual(matrix_mode, non_matrix_mode, 6)
 
@@ -373,7 +380,6 @@ class TestOperator(QiskitAquaTestCase):
             pauli_term = [coeff, Pauli.from_label(pauli)]
             op += Operator(paulis=[pauli_term])
 
-
         for i in range(6):
             op_a = Operator(paulis=[[-coeffs[i], Pauli.from_label(paulis[i])]])
             op += op_a
@@ -522,7 +528,7 @@ class TestOperator(QiskitAquaTestCase):
 
         paulis = ['IXYZ', 'XXZY', 'IIZZ', 'XXYY', 'ZZXX', 'YYYY']
         coeffs = [0.2 + -1j * 0.2, 0.6 + -1j * 0.6, 0.8 + -1j * 0.8,
-                    -0.2 + -1j * 0.2, -0.6 - -1j * 0.6, -0.8 - -1j * 0.8]
+                  -0.2 + -1j * 0.2, -0.6 - -1j * 0.6, -0.8 - -1j * 0.8]
         op = Operator(paulis=[])
         for coeff, pauli in zip(coeffs, paulis):
             pauli_term = [coeff, Pauli.from_label(pauli)]
@@ -565,7 +571,7 @@ class TestOperator(QiskitAquaTestCase):
 
         paulis = ['IXYZ', 'XXZY', 'IIZZ', 'XXYY', 'ZZXX', 'YYYY']
         coeffs = [0.2 + -1j * 0.8, 0.6 + -1j * 0.6, 0.8 + -1j * 0.2,
-                    -0.2 + -1j * 0.8, -0.6 - -1j * 0.6, -0.8 - -1j * 0.2]
+                  -0.2 + -1j * 0.8, -0.6 - -1j * 0.6, -0.8 - -1j * 0.2]
         op = Operator(paulis=[])
         for coeff, pauli in zip(coeffs, paulis):
             pauli_term = [coeff, Pauli.from_label(pauli)]
@@ -582,7 +588,6 @@ class TestOperator(QiskitAquaTestCase):
         op3 = copy.deepcopy(op)
         op3.chop(threshold=0.9)
         self.assertEqual(len(op3.paulis), 0, "\n{}".format(op3.print_operators()))
-
 
     def test_representations(self):
 
@@ -620,17 +625,17 @@ class TestOperator(QiskitAquaTestCase):
         depth = 1
         var_form = RYRZ(op.num_qubits, depth)
         circuit = var_form.construct_circuit(np.array(np.random.randn(var_form.num_parameters)))
-        execute_config = {'shots': 1}
+        run_config = {'shots': 1}
         backend = Aer.get_backend('statevector_simulator')
-        non_matrix_mode = op.eval('paulis', circuit, backend, execute_config)[0]
-        matrix_mode = op.eval('matrix', circuit, backend, execute_config)[0]
+        non_matrix_mode = op.eval('paulis', circuit, backend, run_config=run_config)[0]
+        matrix_mode = op.eval('matrix', circuit, backend, run_config=run_config)[0]
 
         self.assertAlmostEqual(matrix_mode, non_matrix_mode, 6)
 
     def test_load_from_file(self):
         paulis = ['IXYZ', 'XXZY', 'IIZZ', 'XXYY', 'ZZXX', 'YYYY']
         coeffs = [0.2 + -1j * 0.8, 0.6 + -1j * 0.6, 0.8 + -1j * 0.2,
-                    -0.2 + -1j * 0.8, -0.6 - -1j * 0.6, -0.8 - -1j * 0.2]
+                  -0.2 + -1j * 0.8, -0.6 - -1j * 0.6, -0.8 - -1j * 0.2]
         op = Operator(paulis=[])
         for coeff, pauli in zip(coeffs, paulis):
             pauli_term = [coeff, Pauli.from_label(pauli)]
@@ -643,7 +648,6 @@ class TestOperator(QiskitAquaTestCase):
         self.assertEqual(op, load_op)
 
         os.remove('temp_op.json')
-
 
     def test_group_paulis_1(self):
         """
@@ -690,6 +694,7 @@ class TestOperator(QiskitAquaTestCase):
                     passed = p[0] == gp[0]
                     break
             self.assertTrue(passed, "non-existed paulis in grouped_paulis: {}".format(gp[1].to_label()))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_operator.py
+++ b/test/test_operator.py
@@ -99,7 +99,6 @@ class TestOperator(QiskitAquaTestCase):
         non_matrix_mode = self.qubitOp.eval('paulis', circuit, backend,
                                             run_config=run_config, compile_config=compile_config)[0]
         diff = abs(matrix_mode - non_matrix_mode)
-        print(matrix_mode, non_matrix_mode)
         self.assertLess(diff, 0.01, "Without any pass manager, Values: ({} vs {})".format(matrix_mode, non_matrix_mode))
 
     def test_create_from_paulis_0(self):

--- a/test/test_qaoa.py
+++ b/test/test_qaoa.py
@@ -25,7 +25,7 @@ from test.common import QiskitAquaTestCase
 from qiskit_aqua.translators.ising import maxcut
 from qiskit_aqua.algorithms.components.optimizers import COBYLA
 from qiskit_aqua.algorithms.adaptive import QAOA
-from qiskit_aqua import QuantumExpConfig
+from qiskit_aqua import QuantumInstance
 
 w1 = np.array([
     [0, 1, 0, 1],
@@ -62,9 +62,9 @@ class TestQAOA(QiskitAquaTestCase):
         qubitOp, offset = maxcut.get_maxcut_qubitops(w)
 
         qaoa = QAOA(qubitOp, optimizer, p, operator_mode='matrix')
-        quantum_device = QuantumExpConfig(backend)
+        quantum_instance = QuantumInstance(backend)
 
-        result = qaoa.run(quantum_device)
+        result = qaoa.run(quantum_instance)
         x = maxcut.sample_most_likely(result['eigvecs'][0])
         graph_solution = maxcut.get_graph_solution(x)
         self.log.debug('energy:             {}'.format(result['energy']))

--- a/test/test_qaoa.py
+++ b/test/test_qaoa.py
@@ -25,7 +25,7 @@ from test.common import QiskitAquaTestCase
 from qiskit_aqua.translators.ising import maxcut
 from qiskit_aqua.algorithms.components.optimizers import COBYLA
 from qiskit_aqua.algorithms.adaptive import QAOA
-from qiskit_aqua import QuantumDevice
+from qiskit_aqua import QuantumExpConfig
 
 w1 = np.array([
     [0, 1, 0, 1],
@@ -62,7 +62,7 @@ class TestQAOA(QiskitAquaTestCase):
         qubitOp, offset = maxcut.get_maxcut_qubitops(w)
 
         qaoa = QAOA(qubitOp, optimizer, p, operator_mode='matrix')
-        quantum_device = QuantumDevice(backend)
+        quantum_device = QuantumExpConfig(backend)
 
         result = qaoa.run(quantum_device)
         x = maxcut.sample_most_likely(result['eigvecs'][0])

--- a/test/test_qaoa.py
+++ b/test/test_qaoa.py
@@ -62,7 +62,7 @@ class TestQAOA(QiskitAquaTestCase):
         qubitOp, offset = maxcut.get_maxcut_qubitops(w)
 
         qaoa = QAOA(qubitOp, optimizer, p, operator_mode='matrix')
-        quantum_device = QuantumDevice(backend, shots=1)
+        quantum_device = QuantumDevice(backend)
 
         result = qaoa.run(quantum_device)
         x = maxcut.sample_most_likely(result['eigvecs'][0])

--- a/test/test_qaoa.py
+++ b/test/test_qaoa.py
@@ -19,11 +19,13 @@ import unittest
 
 import numpy as np
 from parameterized import parameterized
+from qiskit import Aer
 
 from test.common import QiskitAquaTestCase
 from qiskit_aqua.translators.ising import maxcut
 from qiskit_aqua.algorithms.components.optimizers import COBYLA
 from qiskit_aqua.algorithms.adaptive import QAOA
+from qiskit_aqua import QuantumDevice
 
 w1 = np.array([
     [0, 1, 0, 1],
@@ -55,13 +57,14 @@ class TestQAOA(QiskitAquaTestCase):
         self.log.debug('Testing {}-step QAOA with MaxCut on graph\n{}'.format(p, w))
         np.random.seed(0)
 
+        backend = Aer.get_backend('statevector_simulator')
         optimizer = COBYLA()
         qubitOp, offset = maxcut.get_maxcut_qubitops(w)
 
         qaoa = QAOA(qubitOp, optimizer, p, operator_mode='matrix')
-        qaoa.setup_quantum_backend(backend='statevector_simulator', shots=100)
+        quantum_device = QuantumDevice(backend, shots=1)
 
-        result = qaoa.run()
+        result = qaoa.run(quantum_device)
         x = maxcut.sample_most_likely(result['eigvecs'][0])
         graph_solution = maxcut.get_graph_solution(x)
         self.log.debug('energy:             {}'.format(result['energy']))

--- a/test/test_qpe.py
+++ b/test/test_qpe.py
@@ -25,7 +25,7 @@ from qiskit import Aer
 from qiskit.transpiler import PassManager
 
 from test.common import QiskitAquaTestCase
-from qiskit_aqua import Operator, QuantumDevice
+from qiskit_aqua import Operator, QuantumExpConfig
 from qiskit_aqua.utils import decimal_to_binary
 from qiskit_aqua.algorithms.classical import ExactEigensolver
 from qiskit_aqua.algorithms.components.iqfts import Standard
@@ -95,7 +95,7 @@ class TestQPE(QiskitAquaTestCase):
                   paulis_grouping='random', expansion_mode='suzuki', expansion_order=2)
 
         backend = Aer.get_backend('qasm_simulator')
-        quantum_device = QuantumDevice(backend, shots=100, pass_manager=PassManager())
+        quantum_device = QuantumExpConfig(backend, shots=100, pass_manager=PassManager())
 
         # run qpe
         result = qpe.run(quantum_device)

--- a/test/test_qpe.py
+++ b/test/test_qpe.py
@@ -25,7 +25,7 @@ from qiskit import Aer
 from qiskit.transpiler import PassManager
 
 from test.common import QiskitAquaTestCase
-from qiskit_aqua import Operator, QuantumExpConfig
+from qiskit_aqua import Operator, QuantumInstance
 from qiskit_aqua.utils import decimal_to_binary
 from qiskit_aqua.algorithms.classical import ExactEigensolver
 from qiskit_aqua.algorithms.components.iqfts import Standard
@@ -95,10 +95,10 @@ class TestQPE(QiskitAquaTestCase):
                   paulis_grouping='random', expansion_mode='suzuki', expansion_order=2)
 
         backend = Aer.get_backend('qasm_simulator')
-        quantum_device = QuantumExpConfig(backend, shots=100, pass_manager=PassManager())
+        quantum_instance = QuantumInstance(backend, shots=100, pass_manager=PassManager())
 
         # run qpe
-        result = qpe.run(quantum_device)
+        result = qpe.run(quantum_instance)
         # self.log.debug('transformed operator paulis:\n{}'.format(self.qubitOp.print_operators('paulis')))
 
         # report result

--- a/test/test_qpe.py
+++ b/test/test_qpe.py
@@ -25,7 +25,7 @@ from qiskit import Aer
 from qiskit.transpiler import PassManager
 
 from test.common import QiskitAquaTestCase
-from qiskit_aqua import Operator
+from qiskit_aqua import Operator, QuantumDevice
 from qiskit_aqua.utils import decimal_to_binary
 from qiskit_aqua.algorithms.classical import ExactEigensolver
 from qiskit_aqua.algorithms.components.iqfts import Standard
@@ -95,10 +95,10 @@ class TestQPE(QiskitAquaTestCase):
                   paulis_grouping='random', expansion_mode='suzuki', expansion_order=2)
 
         backend = Aer.get_backend('qasm_simulator')
-        qpe.setup_quantum_backend(backend=backend, shots=100, pass_manager=PassManager())
+        quantum_device = QuantumDevice(backend, shots=100, pass_manager=PassManager())
 
         # run qpe
-        result = qpe.run()
+        result = qpe.run(quantum_device)
         # self.log.debug('transformed operator paulis:\n{}'.format(self.qubitOp.print_operators('paulis')))
 
         # report result

--- a/test/test_qsvm_kernel.py
+++ b/test/test_qsvm_kernel.py
@@ -77,7 +77,7 @@ class TestQSVMKernel(QiskitAquaTestCase):
 
         params = {
             'problem': {'name': 'svm_classification', 'random_seed': self.random_seed},
-            'backend': {'shots': self.shots, 'seed': self.random_seed, 'seed_mapper': self.random_seed},
+            'backend': {'shots': self.shots},
             'algorithm': {
                 'name': 'QSVM.Kernel'
             }
@@ -155,7 +155,7 @@ class TestQSVMKernel(QiskitAquaTestCase):
             'algorithm': {
                 'name': 'QSVM.Kernel',
             },
-            'backend': {'shots': self.shots, 'seed': self.random_seed, 'seed_mapper': self.random_seed},
+            'backend': {'shots': self.shots},
             'multiclass_extension': {'name': 'OneAgainstRest'},
             'feature_map': {'name': 'SecondOrderExpansion', 'depth': 2, 'entangler_map': {0: [1]}}
         }
@@ -195,7 +195,7 @@ class TestQSVMKernel(QiskitAquaTestCase):
             'algorithm': {
                 'name': 'QSVM.Kernel',
             },
-            'backend': {'shots': self.shots, 'seed': self.random_seed, 'seed_mapper': self.random_seed},
+            'backend': {'shots': self.shots},
             'multiclass_extension': {'name': 'AllPairs'},
             'feature_map': {'name': 'SecondOrderExpansion', 'depth': 2, 'entangler_map': {0: [1]}}
         }
@@ -232,7 +232,7 @@ class TestQSVMKernel(QiskitAquaTestCase):
             'algorithm': {
                 'name': 'QSVM.Kernel',
             },
-            'backend': {'shots': self.shots, 'seed': self.random_seed, 'seed_mapper': self.random_seed},
+            'backend': {'shots': self.shots},
             'multiclass_extension': {'name': 'ErrorCorrectingCode', 'code_size': 5},
             'feature_map': {'name': 'SecondOrderExpansion', 'depth': 2, 'entangler_map': {0: [1]}}
         }

--- a/test/test_qsvm_kernel.py
+++ b/test/test_qsvm_kernel.py
@@ -38,21 +38,21 @@ class TestQSVMKernel(QiskitAquaTestCase):
         self.testing_data = {'A': np.asarray([[3.83274304, 2.45044227]]),
                              'B': np.asarray([[3.89557489, 0.31415927]])}
 
-        self.ref_kernel_matrix_training = np.asarray([[1.,         0.84851074, 0.12390137, 0.36669922],
-                                                      [0.84851074, 1.,         0.11950684, 0.45507812],
-                                                      [0.12390137, 0.11950684, 1.,         0.67211914],
-                                                      [0.36669922, 0.45507812, 0.67211914, 1.]])
+        self.ref_kernel_matrix_training = np.asarray([[1., 0.85632324, 0.1184082, 0.36523438],
+                                                      [0.85632324, 1., 0.11352539, 0.45068359],
+                                                      [0.1184082, 0.11352539, 1., 0.6730957],
+                                                      [0.36523438, 0.45068359, 0.6730957, 1.]])
 
-        self.ref_kernel_matrix_testing = np.asarray([[0.14575195, 0.18237305, 0.47644043, 0.14587402],
-                                                     [0.33203125, 0.37573242, 0.0222168,  0.15698242]])
+        self.ref_kernel_matrix_testing = np.asarray([[0.14892578, 0.18115234, 0.47631836, 0.14709473],
+                                                     [0.33239746, 0.3782959, 0.02270508, 0.16418457]])
 
         self.ref_support_vectors = np.asarray([[2.95309709, 2.51327412],
                                                [3.14159265, 4.08407045],
                                                [4.08407045, 2.26194671],
                                                [4.46106157, 2.38761042]])
-        self.ref_alpha = np.asarray([0.39755359, 1.46035009, 0.03446283, 1.82344085])
+        self.ref_alpha = np.asarray([0.38038017, 1.46000306, 0.02371895, 1.81666428])
 
-        self.ref_bias = np.asarray([-0.03624927])
+        self.ref_bias = np.asarray([-0.03570662])
 
         self.svm_input = SVMInput(self.training_data, self.testing_data)
 
@@ -96,7 +96,7 @@ class TestQSVMKernel(QiskitAquaTestCase):
         feature_map = SecondOrderExpansion(num_qubits=num_qubits, depth=2, entangler_map={0: [1]})
         svm = QSVM_Kernel(feature_map, self.training_data, self.testing_data, None)
         svm.random_seed = self.random_seed
-        quantum_device = QuantumDevice(backend, shots=self.shots)
+        quantum_device = QuantumDevice(backend, shots=self.shots, seed=self.random_seed, seed_mapper=self.random_seed)
 
         result = svm.run(quantum_device)
         np.testing.assert_array_almost_equal(

--- a/test/test_qsvm_kernel.py
+++ b/test/test_qsvm_kernel.py
@@ -19,7 +19,7 @@ import numpy as np
 from qiskit import Aer
 
 from test.common import QiskitAquaTestCase
-from qiskit_aqua import run_algorithm, QuantumExpConfig
+from qiskit_aqua import run_algorithm, QuantumInstance
 from qiskit_aqua.input import SVMInput
 from qiskit_aqua.algorithms.components.feature_maps import SecondOrderExpansion
 from qiskit_aqua.algorithms.many_sample import QSVM_Kernel
@@ -96,9 +96,9 @@ class TestQSVMKernel(QiskitAquaTestCase):
         feature_map = SecondOrderExpansion(num_qubits=num_qubits, depth=2, entangler_map={0: [1]})
         svm = QSVM_Kernel(feature_map, self.training_data, self.testing_data, None)
         svm.random_seed = self.random_seed
-        quantum_device = QuantumExpConfig(backend, shots=self.shots, seed=self.random_seed, seed_mapper=self.random_seed)
+        quantum_instance = QuantumInstance(backend, shots=self.shots, seed=self.random_seed, seed_mapper=self.random_seed)
 
-        result = svm.run(quantum_device)
+        result = svm.run(quantum_instance)
         np.testing.assert_array_almost_equal(
             result['kernel_matrix_training'], self.ref_kernel_matrix_training, decimal=4)
         np.testing.assert_array_almost_equal(
@@ -121,8 +121,8 @@ class TestQSVMKernel(QiskitAquaTestCase):
         svm = QSVM_Kernel(feature_map, self.training_data, self.testing_data, None)
         svm.random_seed = self.random_seed
 
-        quantum_device = QuantumExpConfig(backend, seed=self.random_seed, seed_mapper=self.random_seed)
-        result = svm.run(quantum_device)
+        quantum_instance = QuantumInstance(backend, seed=self.random_seed, seed_mapper=self.random_seed)
+        result = svm.run(quantum_instance)
 
         self.assertEqual(len(result['svm']['support_vectors']), 4)
         np.testing.assert_array_almost_equal(

--- a/test/test_qsvm_kernel.py
+++ b/test/test_qsvm_kernel.py
@@ -77,7 +77,7 @@ class TestQSVMKernel(QiskitAquaTestCase):
 
         params = {
             'problem': {'name': 'svm_classification', 'random_seed': self.random_seed},
-            'backend': {'shots': self.shots},
+            'backend': {'shots': self.shots, 'seed': self.random_seed, 'seed_mapper': self.random_seed},
             'algorithm': {
                 'name': 'QSVM.Kernel'
             }
@@ -121,7 +121,7 @@ class TestQSVMKernel(QiskitAquaTestCase):
         svm = QSVM_Kernel(feature_map, self.training_data, self.testing_data, None)
         svm.random_seed = self.random_seed
 
-        quantum_device = QuantumDevice(backend, shots=1)
+        quantum_device = QuantumDevice(backend, seed=self.random_seed, seed_mapper=self.random_seed)
         result = svm.run(quantum_device)
 
         self.assertEqual(len(result['svm']['support_vectors']), 4)
@@ -155,7 +155,7 @@ class TestQSVMKernel(QiskitAquaTestCase):
             'algorithm': {
                 'name': 'QSVM.Kernel',
             },
-            'backend': {'shots': self.shots},
+            'backend': {'shots': self.shots, 'seed': self.random_seed, 'seed_mapper': self.random_seed},
             'multiclass_extension': {'name': 'OneAgainstRest'},
             'feature_map': {'name': 'SecondOrderExpansion', 'depth': 2, 'entangler_map': {0: [1]}}
         }
@@ -195,7 +195,7 @@ class TestQSVMKernel(QiskitAquaTestCase):
             'algorithm': {
                 'name': 'QSVM.Kernel',
             },
-            'backend': {'shots': self.shots},
+            'backend': {'shots': self.shots, 'seed': self.random_seed, 'seed_mapper': self.random_seed},
             'multiclass_extension': {'name': 'AllPairs'},
             'feature_map': {'name': 'SecondOrderExpansion', 'depth': 2, 'entangler_map': {0: [1]}}
         }
@@ -232,7 +232,7 @@ class TestQSVMKernel(QiskitAquaTestCase):
             'algorithm': {
                 'name': 'QSVM.Kernel',
             },
-            'backend': {'shots': self.shots},
+            'backend': {'shots': self.shots, 'seed': self.random_seed, 'seed_mapper': self.random_seed},
             'multiclass_extension': {'name': 'ErrorCorrectingCode', 'code_size': 5},
             'feature_map': {'name': 'SecondOrderExpansion', 'depth': 2, 'entangler_map': {0: [1]}}
         }

--- a/test/test_qsvm_kernel.py
+++ b/test/test_qsvm_kernel.py
@@ -19,7 +19,7 @@ import numpy as np
 from qiskit import Aer
 
 from test.common import QiskitAquaTestCase
-from qiskit_aqua import run_algorithm
+from qiskit_aqua import run_algorithm, QuantumDevice
 from qiskit_aqua.input import SVMInput
 from qiskit_aqua.algorithms.components.feature_maps import SecondOrderExpansion
 from qiskit_aqua.algorithms.many_sample import QSVM_Kernel
@@ -96,9 +96,9 @@ class TestQSVMKernel(QiskitAquaTestCase):
         feature_map = SecondOrderExpansion(num_qubits=num_qubits, depth=2, entangler_map={0: [1]})
         svm = QSVM_Kernel(feature_map, self.training_data, self.testing_data, None)
         svm.random_seed = self.random_seed
-        svm.setup_quantum_backend(backend=backend, shots=self.shots)
+        quantum_device = QuantumDevice(backend, shots=self.shots)
 
-        result = svm.run()
+        result = svm.run(quantum_device)
         np.testing.assert_array_almost_equal(
             result['kernel_matrix_training'], self.ref_kernel_matrix_training, decimal=4)
         np.testing.assert_array_almost_equal(
@@ -120,8 +120,9 @@ class TestQSVMKernel(QiskitAquaTestCase):
         feature_map = SecondOrderExpansion(num_qubits=num_qubits, depth=2, entangler_map={0: [1]})
         svm = QSVM_Kernel(feature_map, self.training_data, self.testing_data, None)
         svm.random_seed = self.random_seed
-        svm.setup_quantum_backend(backend=backend)
-        result = svm.run()
+
+        quantum_device = QuantumDevice(backend, shots=1)
+        result = svm.run(quantum_device)
 
         self.assertEqual(len(result['svm']['support_vectors']), 4)
         np.testing.assert_array_almost_equal(

--- a/test/test_qsvm_kernel.py
+++ b/test/test_qsvm_kernel.py
@@ -19,7 +19,7 @@ import numpy as np
 from qiskit import Aer
 
 from test.common import QiskitAquaTestCase
-from qiskit_aqua import run_algorithm, QuantumDevice
+from qiskit_aqua import run_algorithm, QuantumExpConfig
 from qiskit_aqua.input import SVMInput
 from qiskit_aqua.algorithms.components.feature_maps import SecondOrderExpansion
 from qiskit_aqua.algorithms.many_sample import QSVM_Kernel
@@ -96,7 +96,7 @@ class TestQSVMKernel(QiskitAquaTestCase):
         feature_map = SecondOrderExpansion(num_qubits=num_qubits, depth=2, entangler_map={0: [1]})
         svm = QSVM_Kernel(feature_map, self.training_data, self.testing_data, None)
         svm.random_seed = self.random_seed
-        quantum_device = QuantumDevice(backend, shots=self.shots, seed=self.random_seed, seed_mapper=self.random_seed)
+        quantum_device = QuantumExpConfig(backend, shots=self.shots, seed=self.random_seed, seed_mapper=self.random_seed)
 
         result = svm.run(quantum_device)
         np.testing.assert_array_almost_equal(
@@ -121,7 +121,7 @@ class TestQSVMKernel(QiskitAquaTestCase):
         svm = QSVM_Kernel(feature_map, self.training_data, self.testing_data, None)
         svm.random_seed = self.random_seed
 
-        quantum_device = QuantumDevice(backend, seed=self.random_seed, seed_mapper=self.random_seed)
+        quantum_device = QuantumExpConfig(backend, seed=self.random_seed, seed_mapper=self.random_seed)
         result = svm.run(quantum_device)
 
         self.assertEqual(len(result['svm']['support_vectors']), 4)

--- a/test/test_qsvm_variational.py
+++ b/test/test_qsvm_variational.py
@@ -49,7 +49,7 @@ class TestQSVMVariational(QiskitAquaTestCase):
         params = {
             'problem': {'name': 'svm_classification', 'random_seed': self.random_seed},
             'algorithm': {'name': 'QSVM.Variational'},
-            'backend': {'name': 'qasm_simulator', 'shots': 1024},
+            'backend': {'name': 'qasm_simulator', 'shots': 1024, 'seed': self.random_seed, 'seed_mapper': self.random_seed},
             'optimizer': {'name': 'SPSA', 'max_trials': 10, 'save_steps': 1},
             'variational_form': {'name': 'RYRZ', 'depth': 3},
             'feature_map': {'name': 'SecondOrderExpansion', 'depth': 2}
@@ -74,7 +74,7 @@ class TestQSVMVariational(QiskitAquaTestCase):
         svm = QSVMVariational(optimizer, feature_map, var_form, self.training_data, self.testing_data)
         svm.random_seed = self.random_seed
 
-        quantum_device = QuantumDevice(backend, shots=1024)
+        quantum_device = QuantumDevice(backend, shots=1024, seed=self.random_seed, seed_mapper=self.random_seed)
         result = svm.run(quantum_device)
 
         np.testing.assert_array_almost_equal(result['opt_params'], self.ref_opt_params, decimal=4)

--- a/test/test_qsvm_variational.py
+++ b/test/test_qsvm_variational.py
@@ -20,7 +20,7 @@ from qiskit import Aer
 
 from test.common import QiskitAquaTestCase
 from qiskit_aqua.input import SVMInput
-from qiskit_aqua import run_algorithm, QuantumExpConfig
+from qiskit_aqua import run_algorithm, QuantumInstance
 from qiskit_aqua.algorithms.adaptive import QSVMVariational
 from qiskit_aqua.algorithms.components.optimizers import SPSA
 from qiskit_aqua.algorithms.components.feature_maps import SecondOrderExpansion
@@ -36,10 +36,9 @@ class TestQSVMVariational(QiskitAquaTestCase):
         self.testing_data = {'A': np.asarray([[3.83274304, 2.45044227]]),
                              'B': np.asarray([[3.89557489, 0.31415927]])}
 
-
-        self.ref_opt_params = np.asarray([2.6985,   1.5935,   2.2456,  -6.255 ,  -4.3215,  -5.41  ,
-        -6.9215,   0.2656,   1.5701,  -4.677 ,   2.6987, -11.7649,
-        -2.3141,  -2.7084,   0.0622,  -0.1577])
+        self.ref_opt_params = np.asarray([2.6985,   1.5935,   2.2456,  -6.255,  -4.3215,  -5.41,
+                                          -6.9215,   0.2656,   1.5701,  -4.677,   2.6987, -11.7649,
+                                          -2.3141,  -2.7084,   0.0622,  -0.1577])
         self.ref_train_loss = 0.6294606017231916
 
         self.svm_input = SVMInput(self.training_data, self.testing_data)
@@ -74,8 +73,8 @@ class TestQSVMVariational(QiskitAquaTestCase):
         svm = QSVMVariational(optimizer, feature_map, var_form, self.training_data, self.testing_data)
         svm.random_seed = self.random_seed
 
-        quantum_device = QuantumExpConfig(backend, shots=1024, seed=self.random_seed, seed_mapper=self.random_seed)
-        result = svm.run(quantum_device)
+        quantum_instance = QuantumInstance(backend, shots=1024, seed=self.random_seed, seed_mapper=self.random_seed)
+        result = svm.run(quantum_instance)
 
         np.testing.assert_array_almost_equal(result['opt_params'], self.ref_opt_params, decimal=4)
         np.testing.assert_array_almost_equal(result['training_loss'], self.ref_train_loss, decimal=8)

--- a/test/test_qsvm_variational.py
+++ b/test/test_qsvm_variational.py
@@ -20,7 +20,7 @@ from qiskit import Aer
 
 from test.common import QiskitAquaTestCase
 from qiskit_aqua.input import SVMInput
-from qiskit_aqua import run_algorithm, QuantumDevice
+from qiskit_aqua import run_algorithm, QuantumExpConfig
 from qiskit_aqua.algorithms.adaptive import QSVMVariational
 from qiskit_aqua.algorithms.components.optimizers import SPSA
 from qiskit_aqua.algorithms.components.feature_maps import SecondOrderExpansion
@@ -74,7 +74,7 @@ class TestQSVMVariational(QiskitAquaTestCase):
         svm = QSVMVariational(optimizer, feature_map, var_form, self.training_data, self.testing_data)
         svm.random_seed = self.random_seed
 
-        quantum_device = QuantumDevice(backend, shots=1024, seed=self.random_seed, seed_mapper=self.random_seed)
+        quantum_device = QuantumExpConfig(backend, shots=1024, seed=self.random_seed, seed_mapper=self.random_seed)
         result = svm.run(quantum_device)
 
         np.testing.assert_array_almost_equal(result['opt_params'], self.ref_opt_params, decimal=4)

--- a/test/test_qsvm_variational.py
+++ b/test/test_qsvm_variational.py
@@ -49,7 +49,7 @@ class TestQSVMVariational(QiskitAquaTestCase):
         params = {
             'problem': {'name': 'svm_classification', 'random_seed': self.random_seed},
             'algorithm': {'name': 'QSVM.Variational'},
-            'backend': {'name': 'qasm_simulator', 'shots': 1024, 'seed': self.random_seed, 'seed_mapper': self.random_seed},
+            'backend': {'name': 'qasm_simulator', 'shots': 1024},
             'optimizer': {'name': 'SPSA', 'max_trials': 10, 'save_steps': 1},
             'variational_form': {'name': 'RYRZ', 'depth': 3},
             'feature_map': {'name': 'SecondOrderExpansion', 'depth': 2}

--- a/test/test_qsvm_variational.py
+++ b/test/test_qsvm_variational.py
@@ -20,7 +20,7 @@ from qiskit import Aer
 
 from test.common import QiskitAquaTestCase
 from qiskit_aqua.input import SVMInput
-from qiskit_aqua import run_algorithm
+from qiskit_aqua import run_algorithm, QuantumDevice
 from qiskit_aqua.algorithms.adaptive import QSVMVariational
 from qiskit_aqua.algorithms.components.optimizers import SPSA
 from qiskit_aqua.algorithms.components.feature_maps import SecondOrderExpansion
@@ -73,8 +73,9 @@ class TestQSVMVariational(QiskitAquaTestCase):
 
         svm = QSVMVariational(optimizer, feature_map, var_form, self.training_data, self.testing_data)
         svm.random_seed = self.random_seed
-        svm.setup_quantum_backend(backend=backend, shots=1024)
-        result = svm.run()
+
+        quantum_device = QuantumDevice(backend, shots=1024)
+        result = svm.run(quantum_device)
 
         np.testing.assert_array_almost_equal(result['opt_params'], self.ref_opt_params, decimal=4)
         np.testing.assert_array_almost_equal(result['training_loss'], self.ref_train_loss, decimal=8)

--- a/test/test_vqe.py
+++ b/test/test_vqe.py
@@ -22,7 +22,7 @@ from parameterized import parameterized
 from qiskit import Aer
 
 from test.common import QiskitAquaTestCase
-from qiskit_aqua import Operator, run_algorithm, QuantumExpConfig
+from qiskit_aqua import Operator, run_algorithm, QuantumInstance
 from qiskit_aqua.input import EnergyInput
 from qiskit_aqua.algorithms.components.variational_forms import RY
 from qiskit_aqua.algorithms.components.optimizers import L_BFGS_B
@@ -101,8 +101,8 @@ class TestVQE(QiskitAquaTestCase):
         var_form = RY(num_qubits, 3, initial_state=init_state)
         optimizer = L_BFGS_B()
         algo = VQE(self.algo_input.qubit_op, var_form, optimizer, 'matrix')
-        quantum_device = QuantumExpConfig(backend)
-        result = algo.run(quantum_device)
+        quantum_instance = QuantumInstance(backend)
+        result = algo.run(quantum_instance)
         self.assertAlmostEqual(result['energy'], -1.85727503)
 
 

--- a/test/test_vqe.py
+++ b/test/test_vqe.py
@@ -22,7 +22,7 @@ from parameterized import parameterized
 from qiskit import Aer
 
 from test.common import QiskitAquaTestCase
-from qiskit_aqua import Operator, run_algorithm
+from qiskit_aqua import Operator, run_algorithm, QuantumDevice
 from qiskit_aqua.input import EnergyInput
 from qiskit_aqua.algorithms.components.variational_forms import RY
 from qiskit_aqua.algorithms.components.optimizers import L_BFGS_B
@@ -48,7 +48,7 @@ class TestVQE(QiskitAquaTestCase):
     def test_vqe_via_run_algorithm(self):
         params = {
             'algorithm': {'name': 'VQE'},
-            'backend': {'name': 'statevector_simulator'},
+            'backend': {'name': 'statevector_simulator', 'shots': 1},
         }
         result = run_algorithm(params, self.algo_input)
         self.assertAlmostEqual(result['energy'], -1.85727503)
@@ -75,7 +75,7 @@ class TestVQE(QiskitAquaTestCase):
         params = {
             'algorithm': {'name': 'VQE'},
             'optimizer': {'name': name},
-            'backend': {'name': 'statevector_simulator'}
+            'backend': {'name': 'statevector_simulator', 'shots': 1}
         }
         result = run_algorithm(params, self.algo_input)
         self.assertAlmostEqual(result['energy'], -1.85727503, places=places)
@@ -85,12 +85,13 @@ class TestVQE(QiskitAquaTestCase):
         ['RYRZ', 5]
     ])
     def test_vqe_var_forms(self, name, places):
+        backend = Aer.get_backend('statevector_simulator')
         params = {
             'algorithm': {'name': 'VQE'},
             'variational_form': {'name': name},
-            'backend': {'name': 'statevector_simulator'}
+            'backend': {'shots': 1}
         }
-        result = run_algorithm(params, self.algo_input)
+        result = run_algorithm(params, self.algo_input, backend=backend)
         self.assertAlmostEqual(result['energy'], -1.85727503, places=places)
 
     def test_vqe_direct(self):
@@ -100,8 +101,8 @@ class TestVQE(QiskitAquaTestCase):
         var_form = RY(num_qubits, 3, initial_state=init_state)
         optimizer = L_BFGS_B()
         algo = VQE(self.algo_input.qubit_op, var_form, optimizer, 'matrix')
-        algo.setup_quantum_backend(backend=backend)
-        result = algo.run()
+        quantum_device = QuantumDevice(backend, shots=1)
+        result = algo.run(quantum_device)
         self.assertAlmostEqual(result['energy'], -1.85727503)
 
 

--- a/test/test_vqe.py
+++ b/test/test_vqe.py
@@ -110,8 +110,8 @@ class TestVQE(QiskitAquaTestCase):
         var_form = RY(num_qubits, 3, initial_state=init_state)
         optimizer = L_BFGS_B()
         algo = VQE(self.algo_input.qubit_op, var_form, optimizer, 'matrix', batch_mode=batch_mode)
-        algo.setup_quantum_backend(backend=backend)
-        result = algo.run()
+        quantum_instance = QuantumInstance(backend)
+        result = algo.run(quantum_instance)
         self.assertAlmostEqual(result['energy'], -1.85727503)
 
 

--- a/test/test_vqe.py
+++ b/test/test_vqe.py
@@ -101,7 +101,7 @@ class TestVQE(QiskitAquaTestCase):
         var_form = RY(num_qubits, 3, initial_state=init_state)
         optimizer = L_BFGS_B()
         algo = VQE(self.algo_input.qubit_op, var_form, optimizer, 'matrix')
-        quantum_device = QuantumDevice(backend, shots=1)
+        quantum_device = QuantumDevice(backend)
         result = algo.run(quantum_device)
         self.assertAlmostEqual(result['energy'], -1.85727503)
 

--- a/test/test_vqe.py
+++ b/test/test_vqe.py
@@ -22,7 +22,7 @@ from parameterized import parameterized
 from qiskit import Aer
 
 from test.common import QiskitAquaTestCase
-from qiskit_aqua import Operator, run_algorithm, QuantumDevice
+from qiskit_aqua import Operator, run_algorithm, QuantumExpConfig
 from qiskit_aqua.input import EnergyInput
 from qiskit_aqua.algorithms.components.variational_forms import RY
 from qiskit_aqua.algorithms.components.optimizers import L_BFGS_B
@@ -101,7 +101,7 @@ class TestVQE(QiskitAquaTestCase):
         var_form = RY(num_qubits, 3, initial_state=init_state)
         optimizer = L_BFGS_B()
         algo = VQE(self.algo_input.qubit_op, var_form, optimizer, 'matrix')
-        quantum_device = QuantumDevice(backend)
+        quantum_device = QuantumExpConfig(backend)
         result = algo.run(quantum_device)
         self.assertAlmostEqual(result['energy'], -1.85727503)
 

--- a/test/test_vqe2iqpe.py
+++ b/test/test_vqe2iqpe.py
@@ -22,7 +22,7 @@ from qiskit import Aer
 from qiskit.transpiler import PassManager
 
 from test.common import QiskitAquaTestCase
-from qiskit_aqua import Operator, QuantumDevice
+from qiskit_aqua import Operator, QuantumExpConfig
 from qiskit_aqua.input import EnergyInput
 from qiskit_aqua.utils import decimal_to_binary
 from qiskit_aqua.algorithms.components.initial_states.varformbased import VarFormBased
@@ -55,7 +55,7 @@ class TestVQE2IQPE(QiskitAquaTestCase):
         optimizer = SPSA(max_trials=10)
         # optimizer.set_options(**{'max_trials': 500})
         algo = VQE(self.algo_input.qubit_op, var_form, optimizer, 'paulis')
-        quantum_device = QuantumDevice(backend)
+        quantum_device = QuantumExpConfig(backend)
         result = algo.run(quantum_device)
 
         self.log.debug('VQE result: {}.'.format(result))
@@ -68,7 +68,7 @@ class TestVQE2IQPE(QiskitAquaTestCase):
         state_in = VarFormBased(var_form, result['opt_params'])
         iqpe = IQPE(self.algo_input.qubit_op, state_in, num_time_slices, num_iterations,
                     paulis_grouping='random', expansion_mode='suzuki', expansion_order=2)
-        quantum_device = QuantumDevice(backend, shots=100, pass_manager=PassManager(),
+        quantum_device = QuantumExpConfig(backend, shots=100, pass_manager=PassManager(),
                                        seed=self.random_seed, seed_mapper=self.random_seed)
         result = iqpe.run(quantum_device)
 

--- a/test/test_vqe2iqpe.py
+++ b/test/test_vqe2iqpe.py
@@ -35,7 +35,8 @@ from qiskit_aqua.algorithms.single_sample import IQPE
 class TestVQE2IQPE(QiskitAquaTestCase):
 
     def setUp(self):
-        np.random.seed(0)
+        self.random_seed = 0
+        np.random.seed(self.random_seed)
         pauli_dict = {
             'paulis': [{"coeff": {"imag": 0.0, "real": -1.052373245772859}, "label": "II"},
                        {"coeff": {"imag": 0.0, "real": 0.39793742484318045}, "label": "IZ"},
@@ -67,7 +68,8 @@ class TestVQE2IQPE(QiskitAquaTestCase):
         state_in = VarFormBased(var_form, result['opt_params'])
         iqpe = IQPE(self.algo_input.qubit_op, state_in, num_time_slices, num_iterations,
                     paulis_grouping='random', expansion_mode='suzuki', expansion_order=2)
-        quantum_device = QuantumDevice(backend, shots=100, pass_manager=PassManager())
+        quantum_device = QuantumDevice(backend, shots=100, pass_manager=PassManager(),
+                                       seed=self.random_seed, seed_mapper=self.random_seed)
         result = iqpe.run(quantum_device)
 
         self.log.debug('top result str label:         {}'.format(result['top_measurement_label']))

--- a/test/test_vqe2iqpe.py
+++ b/test/test_vqe2iqpe.py
@@ -22,7 +22,7 @@ from qiskit import Aer
 from qiskit.transpiler import PassManager
 
 from test.common import QiskitAquaTestCase
-from qiskit_aqua import Operator, QuantumExpConfig
+from qiskit_aqua import Operator, QuantumInstance
 from qiskit_aqua.input import EnergyInput
 from qiskit_aqua.utils import decimal_to_binary
 from qiskit_aqua.algorithms.components.initial_states.varformbased import VarFormBased
@@ -55,8 +55,8 @@ class TestVQE2IQPE(QiskitAquaTestCase):
         optimizer = SPSA(max_trials=10)
         # optimizer.set_options(**{'max_trials': 500})
         algo = VQE(self.algo_input.qubit_op, var_form, optimizer, 'paulis')
-        quantum_device = QuantumExpConfig(backend)
-        result = algo.run(quantum_device)
+        quantum_instance = QuantumInstance(backend)
+        result = algo.run(quantum_instance)
 
         self.log.debug('VQE result: {}.'.format(result))
 
@@ -68,9 +68,9 @@ class TestVQE2IQPE(QiskitAquaTestCase):
         state_in = VarFormBased(var_form, result['opt_params'])
         iqpe = IQPE(self.algo_input.qubit_op, state_in, num_time_slices, num_iterations,
                     paulis_grouping='random', expansion_mode='suzuki', expansion_order=2)
-        quantum_device = QuantumExpConfig(backend, shots=100, pass_manager=PassManager(),
+        quantum_instance = QuantumInstance(backend, shots=100, pass_manager=PassManager(),
                                        seed=self.random_seed, seed_mapper=self.random_seed)
-        result = iqpe.run(quantum_device)
+        result = iqpe.run(quantum_instance)
 
         self.log.debug('top result str label:         {}'.format(result['top_measurement_label']))
         self.log.debug('top result in decimal:        {}'.format(result['top_measurement_decimal']))

--- a/test/test_vqe2iqpe.py
+++ b/test/test_vqe2iqpe.py
@@ -22,7 +22,7 @@ from qiskit import Aer
 from qiskit.transpiler import PassManager
 
 from test.common import QiskitAquaTestCase
-from qiskit_aqua import Operator
+from qiskit_aqua import Operator, QuantumDevice
 from qiskit_aqua.input import EnergyInput
 from qiskit_aqua.utils import decimal_to_binary
 from qiskit_aqua.algorithms.components.initial_states.varformbased import VarFormBased
@@ -54,8 +54,8 @@ class TestVQE2IQPE(QiskitAquaTestCase):
         optimizer = SPSA(max_trials=10)
         # optimizer.set_options(**{'max_trials': 500})
         algo = VQE(self.algo_input.qubit_op, var_form, optimizer, 'paulis')
-        algo.setup_quantum_backend(backend=backend)
-        result = algo.run()
+        quantum_device = QuantumDevice(backend)
+        result = algo.run(quantum_device)
 
         self.log.debug('VQE result: {}.'.format(result))
 
@@ -67,9 +67,8 @@ class TestVQE2IQPE(QiskitAquaTestCase):
         state_in = VarFormBased(var_form, result['opt_params'])
         iqpe = IQPE(self.algo_input.qubit_op, state_in, num_time_slices, num_iterations,
                     paulis_grouping='random', expansion_mode='suzuki', expansion_order=2)
-        iqpe.setup_quantum_backend(backend=backend, shots=100, pass_manager=PassManager())
-
-        result = iqpe.run()
+        quantum_device = QuantumDevice(backend, shots=100, pass_manager=PassManager())
+        result = iqpe.run(quantum_device)
 
         self.log.debug('top result str label:         {}'.format(result['top_measurement_label']))
         self.log.debug('top result in decimal:        {}'.format(result['top_measurement_decimal']))


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

introduce the concept of the quantum device to decouple quantum backend and quantum algorithm. (#153)

Add the `QuantumExpConfig` class to hold the backend and all settings for compile/run quantum circuits,
and setting for retrieving the results.

This class is the only interface between Aqua and Terra; therefore, in the future, all circuits related optimization would happen here.


### Details and comments
1. support save and load model for QSVM.kernel and QSVM.variational
2. for most algorithms, a unified `construct_circuit` method is added to get the circuit.
3. internally, split the setting related to Terra to 4 configs
    -  backend_config: config, seed, [coupling_map, basis_gates dervied from backend directly]
    -  compile_config: pass_manager, initial_layout, seed_mapper
    -  run_config: shots, max_credits
    -  qjob_config: timeout, wait

